### PR TITLE
9 add a new building zone model to dynamically change thermal comfort parameters

### DIFF
--- a/BuildingSystems/Applications/DistrictSimulation/HCBC_Comfort.mo
+++ b/BuildingSystems/Applications/DistrictSimulation/HCBC_Comfort.mo
@@ -1,0 +1,2431 @@
+within BuildingSystems.Applications.DistrictSimulation;
+model HCBC_Comfort
+  "Model including buildings of the university campus Berlin-Charlottenburg (HCBC) without DHN"
+  extends Modelica.Icons.Example;
+  Modelica.Units.SI.Heat Q_district(displayUnit="kWh")
+    "Heating load of all buildings";
+  model Building
+    "Building model with four capacities used in conjunction with parameter maps for campus simulations"
+  extends BuildingSystems.Buildings.BaseClasses.BuildingTemplate(
+    nIdealLoads = 1,
+    nSurfacesSolid=1,
+    surfacesToAmbience(nSurfaces=9),
+    nZones=1);
+  BuildingSystems.Buildings.Zones.ZoneTemplateAirvolumeMixed zone(
+    calcThermalComfort = true,
+    nConstructions=10,
+    V=parameterMap.VZon,
+    height=parameterMap.heightZon,
+    Q_flow_heatingMax=parameterMap.Q_flowHea,
+    Q_flow_coolingMax=parameterMap.Q_flowCoo,
+    nHeatSources=nHeatSources,
+    heatSources=heatSources)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall1(
+    constructionData=wall1Construction,
+    abs_2=0.75,
+    width=parameterMap.widthOutCap,
+    height=parameterMap.heightOutCap,
+    abs_1=0.0)
+    annotation (Placement(transformation(extent={{-17,19},{17,-19}},
+          rotation=90,
+          origin={-33,35})));
+  BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall2(
+    constructionData=wall2Construction,
+    abs_2=0.75,
+    width=parameterMap.widthOutCap,
+    height=parameterMap.heightOutCap,
+    abs_1=0.0)
+    annotation (Placement(transformation(extent={{18,-20},{46,20}})));
+  BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall3(
+    constructionData=wall3Construction,
+    abs_2=0.75,
+    width=parameterMap.widthOutCap,
+    height=parameterMap.heightOutCap,
+    abs_1=0.0)
+    annotation (Placement(transformation(extent={{-13,-20},{13,20}},
+          rotation=-90,
+          origin={10,-29})));
+  BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall4(
+    constructionData=wall4Construction,
+    abs_2=0.75,
+    width=parameterMap.widthOutCap,
+    height=parameterMap.heightOutCap,
+    abs_1=0.0)
+    annotation (Placement(transformation(extent={{-22,-18},{-62,18}})));
+  BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes ceiling(
+    constructionData=ceilingConstruction,
+    abs_2=0.75,
+    width=parameterMap.widthOutCap,
+    height=parameterMap.heightOutCap,
+    abs_1=0.0)
+    annotation (Placement(transformation(extent={{15,-17},{-15,17}},
+          rotation=90,
+          origin={-5,89})));
+  BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes bottom(
+    constructionData=bottomConstruction,
+    abs_2=0.75,
+    width=parameterMap.widthOutCap,
+    height=parameterMap.heightOutCap,
+    abs_1=0.0)
+    annotation (Placement(transformation(extent={{-15,-21},{15,21}},
+          rotation=-90,
+          origin={1,-75})));
+  BuildingSystems.Buildings.Constructions.Windows.Window window1(
+    width=parameterMap.widthWin1,
+    height=parameterMap.heightWin1,
+    angleDegAzi=parameterMap.angleDegAziWin1,
+    constructionData(
+      UValGla = parameterMap.windowU,
+      UValFra = parameterMap.windowU,
+      g = 0.6,
+      b0 = 0.7))
+    annotation (Placement(transformation(extent={{-15,-21},{15,21}},
+          rotation=90,
+          origin={99,43})));
+  BuildingSystems.Buildings.Constructions.Windows.Window window2(
+    width=parameterMap.widthWin1,
+    height=parameterMap.heightWin1,
+    angleDegAzi=parameterMap.angleDegAziWin1,
+    constructionData(
+      UValGla = parameterMap.windowU,
+      UValFra = parameterMap.windowU,
+      g = 0.6,
+      b0 = 0.7))
+    annotation (Placement(transformation(extent={{74,-18},{106,18}})));
+  BuildingSystems.Buildings.Constructions.Windows.Window window3(
+    width=parameterMap.widthWin1,
+    height=parameterMap.heightWin1,
+    angleDegAzi=parameterMap.angleDegAziWin1,
+    constructionData(
+      UValGla = parameterMap.windowU,
+      UValFra = parameterMap.windowU,
+      g = 0.6,
+      b0 = 0.7))
+    annotation (Placement(transformation(extent={{-15,-21},{15,21}},
+          rotation=-90,
+          origin={101,-35})));
+  BuildingSystems.Buildings.Constructions.Windows.Window window4(
+    width=parameterMap.widthWin1,
+    height=parameterMap.heightWin1,
+    angleDegAzi=parameterMap.angleDegAziWin1,
+    constructionData(
+      UValGla = parameterMap.windowU,
+      UValFra = parameterMap.windowU,
+      g = 0.6,
+      b0 = 0.7))
+    annotation (Placement(transformation(extent={{-18,-66},{-60,-26}})));
+  BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction wall1Construction(
+    nLayers=1,
+    thickness={parameterMap.thickness},
+    material={
+      BuildingSystems.HAM.Data.MaterialProperties.BaseClasses.MaterialThermalGeneral(
+      lambda=parameterMap.lambdaOut,
+      c=parameterMap.cOut,
+      rho=parameterMap.rhoOut)})
+    annotation (Placement(transformation(extent={{24,42},{44,62}})));
+
+  BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction wall2Construction(
+    nLayers=1,
+    thickness={parameterMap.thickness},
+    material={
+      BuildingSystems.HAM.Data.MaterialProperties.BaseClasses.MaterialThermalGeneral(
+      lambda=parameterMap.lambdaOut,
+      c=parameterMap.cOut,
+      rho=parameterMap.rhoOut)})
+    annotation (Placement(transformation(extent={{130,-18},{150,2}})));
+
+  BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction wall3Construction(
+    nLayers=1,
+    thickness={parameterMap.thickness},
+    material={
+      BuildingSystems.HAM.Data.MaterialProperties.BaseClasses.MaterialThermalGeneral(
+      lambda=parameterMap.lambdaOut,
+      c=parameterMap.cOut,
+      rho=parameterMap.rhoOut)})
+    annotation (Placement(transformation(extent={{52,-72},{72,-52}})));
+
+  BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction wall4Construction(
+    nLayers=1,
+    thickness={parameterMap.thickness},
+    material={
+      BuildingSystems.HAM.Data.MaterialProperties.BaseClasses.MaterialThermalGeneral(
+      lambda=parameterMap.lambdaOut,
+      c=parameterMap.cOut,
+      rho=parameterMap.rhoOut)})
+    annotation (Placement(transformation(extent={{-108,-26},{-88,-6}})));
+
+  BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction ceilingConstruction(
+    nLayers=1,
+    thickness={parameterMap.thickness},
+    material={
+      BuildingSystems.HAM.Data.MaterialProperties.BaseClasses.MaterialThermalGeneral(
+      lambda=parameterMap.lambdaOut,
+      c=parameterMap.cOut,
+      rho=parameterMap.rhoOut)})
+    annotation (Placement(transformation(extent={{140,94},{160,114}})));
+
+  BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction bottomConstruction(
+    nLayers=1,
+    thickness={parameterMap.thickness},
+    material={
+      BuildingSystems.HAM.Data.MaterialProperties.BaseClasses.MaterialThermalGeneral(
+      lambda=parameterMap.lambdaOut,
+      c=parameterMap.cOut,
+      rho=parameterMap.rhoOut)})
+    annotation (Placement(transformation(extent={{142,-112},{162,-92}})));
+
+  replaceable parameter ParameterMap parameterMap
+    annotation (choicesAllMatching=true, Placement(transformation(extent={{-118,70},
+              {-98,90}})));
+  equation
+
+  connect(surfacesToAmbience.toConstructionPorts[1], wall1.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-116,2.66454e-15},{-116,0},{
+            -62,0},{-62,64},{-32,64},{-32,38.4},{-33,38.4}},color={127,0,0}));
+  connect(surfacesToAmbience.toConstructionPorts[2], wall2.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-62,2.66454e-15},{-62,64},{
+            60,64},{60,0},{34.8,0}}, color={127,0,0}));
+  connect(surfacesToAmbience.toConstructionPorts[3], wall3.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-62,2.66454e-15},{-62,64},{
+            -136,64},{-136,-46},{10,-46},{10,-31.6}},color={127,0,0}));
+  connect(surfacesToAmbience.toConstructionPorts[4], wall4.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-168,2.66454e-15},{-168,0},{
+            -46,0}},color={127,0,0}));
+
+  connect(surfacesToAmbience.toConstructionPorts[5], ceiling.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-86,2.66454e-15},{-86,0},{
+            -136,0},{-136,64},{-4,64},{-4,86},{-5,86}},color={127,0,0}));
+
+  connect(surfacesToAmbience.toConstructionPorts[6], window1.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-62,2.66454e-15},{-62,64},{
+            99,64},{99,46}},color={127,0,0}));
+  connect(surfacesToAmbience.toConstructionPorts[7], window2.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-62,2.66454e-15},{-62,64},{
+            122,64},{122,0},{93.2,0}},color={127,0,0}));
+  connect(surfacesToAmbience.toConstructionPorts[8], window3.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-136,2.66454e-15},{-136,-46},
+            {101,-46},{101,-38}},color={127,0,0}));
+  connect(surfacesToAmbience.toConstructionPorts[9], window4.toSurfacePort_2)
+    annotation (Line(points={{-170.8,2.66454e-15},{-136,2.66454e-15},{-136,-46},
+            {-43.2,-46}}, color={127,0,0}));
+
+  connect(surfacesToSolids.toConstructionPorts[1], bottom.toSurfacePort_2)
+    annotation (Line(points={{1.33227e-15,-109.6},{1.33227e-15,-70},{1,-70},{1,
+            -78}},color={127,0,0}));
+
+  connect(wall1.toSurfacePort_1, zone.toConstructionPorts[1])
+    annotation (Line(points={{-33,31.6},{-33,30},{-2,30},{-2,-0.9},{0,-0.9}},color={0,0,0}));
+  connect(wall2.toSurfacePort_1, zone.toConstructionPorts[2])
+    annotation (Line(points={{29.2,0},{-14,0},{-14,-0.7},{0,-0.7}},color={0,0,0}));
+  connect(wall3.toSurfacePort_1, zone.toConstructionPorts[3])
+    annotation (Line(points={{10,-26.4},{10,-18},{0,-18},{0,-0.5}},color={0,0,0}));
+  connect(wall4.toSurfacePort_1, zone.toConstructionPorts[4])
+    annotation (Line(points={{-38,0},{-38,-0.3},{0,-0.3}},color={0,0,0}));
+
+  connect(window1.toSurfacePort_1, zone.toConstructionPorts[5])
+    annotation (Line(points={{99,40},{100,40},{100,30},{-2,30},{-2,-0.1},{0,
+            -0.1}}, color={0,0,0}));
+  connect(window2.toSurfacePort_1, zone.toConstructionPorts[6])
+    annotation (Line(points={{86.8,0},{78,0},{78,30},{-2,30},{-2,0},{-14,0},{
+            -14,0.1},{0,0.1}},color={0,0,0}));
+  connect(window3.toSurfacePort_1, zone.toConstructionPorts[7])
+    annotation (Line(points={{101,-32},{100,-32},{100,30},{-2,30},{-2,0.3},{0,
+            0.3}},color={0,0,0}));
+  connect(window4.toSurfacePort_1, zone.toConstructionPorts[8])
+    annotation (Line(points={{-34.8,-46},{0,-46},{0,0.5}},color={0,0,0}));
+
+  connect(bottom.toSurfacePort_1, zone.toConstructionPorts[9])
+    annotation (Line(points={{1,-72},{0,-72},{0,0.7}},color={0,0,0}));
+
+  connect(ceiling.toSurfacePort_1, zone.toConstructionPorts[10]) annotation (
+      Line(points={{-5,92},{18,92},{18,30},{0,30},{0,0.9}},
+                                                          color={0,0,0}));
+
+  connect(airchange[1], zone.airchange) annotation (Line(points={{180,40},{180,
+            40},{60,40},{60,-2},{-11,-2}},
+                                      color={0,0,127}));
+  connect(TAirAmb, zone.TAirAmb)
+    annotation (Line(points={{50,120},{50,-4},{-11,-4}},
+                                                      color={0,0,127}));
+  connect(xAirAmb, zone.xAirAmb)
+    annotation (Line(points={{70,120},{70,-8},{-11,-8}},
+                                                      color={0,0,127}));
+  connect(T_setHeating[1], zone.T_setHeating) annotation (Line(points={{180,80},
+            {180,80},{82,80},{82,20},{-11,20},{-11,7}},
+                                                   color={0,0,127}));
+  connect(T_setCooling[1], zone.T_setCooling) annotation (Line(points={{180,60},
+            {180,60},{82,60},{82,18},{-11,18},{-11,5}},
+                                                   color={0,0,127}));
+  connect(zone.Q_flow_cooling, Q_flow_cooling[1]) annotation (Line(points={{11,7},{
+            11,-2},{20,-2},{20,-64},{-80,-64},{-80,-122}},
+                                         color={0,0,127}));
+    connect(zone.Q_flow_heating, Q_flow_heating[1]) annotation (Line(points={{11,9},{
+            11,-20},{80,-20},{80,-122}},    color={0,0,127}));
+    connect(zone.conHeatSourcesPorts, conHeatSourcesPorts) annotation (Line(
+          points={{-4.9,-10.7},{-4.9,92},{-44,92},{-44,120}},color={127,0,0}));
+    connect(radHeatSourcesPorts, zone.radHeatSourcesPorts)
+      annotation (Line(points={{0,120},{0,-10.7},{4.9,-10.7}},
+                                                             color={127,0,0}));
+
+  end Building;
+
+  record ParameterMap
+    "Parameter map for building information from ATES database"
+    extends Modelica.Icons.Record;
+    // General information
+    parameter Integer id = 0
+      annotation (Dialog(group = "General information"));
+    parameter String name = ""
+      annotation (Dialog(group = "General information"));
+    // Geometry related input parameters
+    parameter Modelica.Units.SI.Length thickness=1
+      annotation (Dialog(group="Geometry related input"));
+    parameter Integer nFloors = 1
+      annotation (Dialog(group = "Geometry related input"));
+    parameter Modelica.Units.SI.Length heightBui=1
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.SI.Volume VBui=1
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.SI.Area ABuiGro=1
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.SI.Area AWal1=1
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.SI.Area AWal2=1
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.SI.Area AWal3=1
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.SI.Area AWal4=1
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.NonSI.Angle_deg angleDegAziWin1=0
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.NonSI.Angle_deg angleDegAziWin2=0
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.NonSI.Angle_deg angleDegAziWin3=0
+      annotation (Dialog(group="Geometry related input"));
+    parameter Modelica.Units.NonSI.Angle_deg angleDegAziWin4=0
+      annotation (Dialog(group="Geometry related input"));
+    // Heat flow rate heating/cooling
+    parameter Modelica.Units.SI.HeatFlowRate Q_flowHea=100000
+      annotation (Dialog(group="Heat flow rate heating/cooling"));
+    parameter Modelica.Units.SI.HeatFlowRate Q_flowCoo=-100000
+      annotation (Dialog(group="Heat flow rate heating/cooling"));
+    // Optimization input parameters
+    parameter Modelica.Units.SI.Temperature TSetHea=273.15 + 20
+      annotation (Dialog(group="Optimization parameters"));
+    parameter Modelica.Units.SI.Temperature TSetCoo=273.15 + 24
+      annotation (Dialog(group="Optimization parameters"));
+    parameter BuildingSystems.Types.AirchangeRate airchange = 0.5
+      annotation (Dialog(group = "Optimization parameters"));
+    parameter BuildingSystems.Types.VolumeHeatCapacity VHCOut = 1000000
+      annotation (Dialog(group = "Optimization parameters"));
+    parameter BuildingSystems.Types.VolumeHeatCapacity VHCInn = 1000000
+      annotation (Dialog(group = "Optimization parameters"));
+    parameter BuildingSystems.Types.VolumeHeatCapacity VHCBas = 1000000
+      annotation (Dialog(group = "Optimization parameters"));
+    parameter Modelica.Units.SI.CoefficientOfHeatTransfer envelopeU=1.2
+      annotation (Dialog(group="Optimization parameters"));
+    parameter Modelica.Units.SI.CoefficientOfHeatTransfer innerU=1.2
+      annotation (Dialog(group="Optimization parameters"));
+    parameter Modelica.Units.SI.CoefficientOfHeatTransfer baseU=1.2
+      annotation (Dialog(group="Optimization parameters"));
+    parameter Modelica.Units.SI.CoefficientOfHeatTransfer windowU=3.0
+      annotation (Dialog(group="Optimization parameters"));
+    parameter Real ratio = 0.3
+      annotation (Dialog(group = "Optimization parameters"));
+    // Derived from previous parameters
+    parameter Modelica.Units.SI.SpecificHeatCapacity cOut=sqrt(VHCOut)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Density rhoOut=sqrt(VHCOut)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.SpecificHeatCapacity cInn=sqrt(VHCInn)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Density rhoInn=sqrt(VHCInn)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.SpecificHeatCapacity cBas=sqrt(VHCBas)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Density rhoBas=sqrt(VHCBas)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.ThermalConductivity lambdaOut=envelopeU*
+        thickness annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.ThermalConductivity lambdaInn=innerU*thickness
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.ThermalConductivity lambdaBas=baseU*thickness
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length heightWin1=sqrt(ratio)*heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length widthWin1=sqrt(ratio)*AWal1/heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length heightWin2=sqrt(ratio)*heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length widthWin2=sqrt(ratio)*AWal2/heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length heightWin3=sqrt(ratio)*heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length widthWin3=sqrt(ratio)*AWal3/heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length heightWin4=sqrt(ratio)*heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length widthWin4=sqrt(ratio)*AWal4/heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Area AHul=ratio*(AWal1 + AWal2 + AWal3 + AWal4)
+         + ABuiGro annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length heightOutCap=sqrt(AHul)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length widthOutCap=sqrt(AHul)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length heightInnCap=lengthBasCap*sqrt(nFloors)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length widthInnCap=widthBasCap*sqrt(nFloors)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length lengthBasCap=sqrt(ABuiGro)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length widthBasCap=sqrt(ABuiGro)
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Volume VZon=VBui
+      annotation (Dialog(group="Derived model parametrization"));
+    parameter Modelica.Units.SI.Length heightZon=heightBui
+      annotation (Dialog(group="Derived model parametrization"));
+  end ParameterMap;
+
+  ParameterMap parameterMap1(
+    nFloors = 9,
+    heightBui = 22,
+    VBui = 110000,
+    ABuiGro = 5100,
+    AWal1 = 2100,
+    AWal2 = 3400,
+    AWal3 = 2100,
+    AWal4 = 3600,
+    angleDegAziWin1 = -7,
+    angleDegAziWin2 = 80,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -117,
+    Q_flowHea(displayUnit = "kW") = 1300000,
+    Q_flowCoo(displayUnit = "kW") = -1300000,
+    TSetHea = 292.75,
+    TSetCoo = 297.15,
+    VHCOut = 62000,
+    VHCInn = 6200,
+    VHCBas = 1000000,
+    envelopeU = 0.7,
+    innerU = 1.2,
+    baseU = 1.2,
+    windowU = 4.0,
+    airchange = 0.5,
+    ratio = 0.28);
+  ParameterMap parameterMap2(
+    nFloors = 3,
+    heightBui = 5,
+    VBui = 1700,
+    ABuiGro = 370,
+    AWal1 = 130,
+    AWal2 = 63,
+    AWal3 = 130,
+    AWal4 = 63,
+    angleDegAziWin1 = 27,
+    angleDegAziWin2 = 119,
+    angleDegAziWin3 = -153,
+    angleDegAziWin4 = -61,
+    Q_flowHea(displayUnit = "kW") = 73000,
+    Q_flowCoo(displayUnit = "kW") = -73000,
+    TSetHea = 291.15,
+    TSetCoo = 393.15,
+    VHCOut = 1600000,
+    VHCInn = 2400000,
+    VHCBas = 1000000,
+    envelopeU = 1.8,
+    innerU = 1.2,
+    baseU = 2.4,
+    windowU = 3.5,
+    airchange = 0.5,
+    ratio = 0.6);
+  ParameterMap parameterMap3(
+    nFloors = 4,
+    heightBui = 12,
+    VBui = 8300,
+    ABuiGro = 720,
+    AWal1 = 610,
+    AWal2 = 160,
+    AWal3 = 610,
+    AWal4 = 150,
+    angleDegAziWin1 = 28,
+    angleDegAziWin2 = 117,
+    angleDegAziWin3 = -151,
+    angleDegAziWin4 = -62,
+    Q_flowHea(displayUnit = "kW") = 150000,
+    Q_flowCoo(displayUnit = "kW") = -150000,
+    TSetHea = 292.15,
+    TSetCoo = 393.15,
+    VHCOut = 160000,
+    VHCInn = 50000,
+    VHCBas = 1000000,
+    envelopeU = 1.69,
+    innerU = 1.2,
+    baseU = 2.2,
+    windowU = 6,
+    airchange = 0.2,
+    ratio = 0.19);
+  ParameterMap parameterMap5(
+    nFloors = 5,
+    heightBui = 15,
+    VBui = 10000,
+    ABuiGro = 720,
+    AWal1 = 370,
+    AWal2 = 410,
+    AWal3 = 400,
+    AWal4 = 420,
+    angleDegAziWin1 = 31,
+    angleDegAziWin2 = 119,
+    angleDegAziWin3 = -152,
+    angleDegAziWin4 = -62,
+    Q_flowHea(displayUnit = "kW") = 210000,
+    Q_flowCoo(displayUnit = "kW") = -210000,
+    TSetHea = 294.95,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 13000,
+    VHCBas = 1000000,
+    envelopeU = 1.6,
+    innerU = 1.2,
+    baseU = 0.5,
+    windowU = 4.9,
+    airchange = 0.36,
+    ratio = 0.46);
+  ParameterMap parameterMap6(
+    nFloors = 7,
+    heightBui = 24,
+    VBui = 90000,
+    ABuiGro = 3800,
+    AWal1 = 2700,
+    AWal2 = 1600,
+    AWal3 = 3000,
+    AWal4 = 1500,
+    angleDegAziWin1 = 38,
+    angleDegAziWin2 = 132,
+    angleDegAziWin3 = -148,
+    angleDegAziWin4 = -63,
+    Q_flowHea(displayUnit = "kW") = 1800000,
+    Q_flowCoo(displayUnit = "kW") = -1800000,
+    TSetHea = 294.75,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 0.7,
+    innerU = 1.2,
+    baseU = 2.1,
+    windowU = 3.9,
+    airchange = 0.5,
+    ratio = 0.4);
+  ParameterMap parameterMap7(
+    nFloors = 3,
+    heightBui = 17,
+    VBui = 89000,
+    ABuiGro = 5400,
+    AWal1 = 5400,
+    AWal2 = 1400,
+    AWal3 = 2500,
+    AWal4 = 1100,
+    angleDegAziWin1 = -7,
+    angleDegAziWin2 = 86,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -94,
+    Q_flowHea(displayUnit = "kW") = 2200000,
+    Q_flowCoo(displayUnit = "kW") = -2200000,
+    TSetHea = 294.35,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 2400000,
+    VHCBas = 1000000,
+    envelopeU = 2.1,
+    innerU = 1.2,
+    baseU = 0.54,
+    windowU = 6,
+    airchange = 0.9,
+    ratio = 0.6);
+  ParameterMap parameterMap8(
+    nFloors = 5,
+    heightBui = 2,
+    VBui = 35000,
+    ABuiGro = 3100,
+    AWal1 = 440,
+    AWal2 = 1200,
+    AWal3 = 490,
+    AWal4 = 1200,
+    angleDegAziWin1 = -5,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -99,
+    Q_flowHea(displayUnit = "kW") = 330000,
+    Q_flowCoo(displayUnit = "kW") = -330000,
+    TSetHea = 293.15,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 390000,
+    VHCBas = 1000000,
+    envelopeU = 0.5,
+    innerU = 1.2,
+    baseU = 1.1,
+    windowU = 4.8,
+    airchange = 0.3,
+    ratio = 0.05);
+  ParameterMap parameterMap9(
+    nFloors = 5,
+    heightBui = 21,
+    VBui = 94000,
+    ABuiGro = 4200,
+    AWal1 = 3700,
+    AWal2 = 710,
+    AWal3 = 3100,
+    AWal4 = 2200,
+    angleDegAziWin1 = 29,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -92,
+    Q_flowHea(displayUnit = "kW") = 1000000,
+    Q_flowCoo(displayUnit = "kW") = -1000000,
+    TSetHea = 293.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 13000,
+    VHCBas = 1000000,
+    envelopeU = 1,
+    innerU = 1.2,
+    baseU = 1.0,
+    windowU = 2.5,
+    airchange = 0.4,
+    ratio = 0.3);
+  ParameterMap parameterMap10(
+    nFloors = 4,
+    heightBui = 14,
+    VBui = 48000,
+    ABuiGro = 3300,
+    AWal1 = 1500,
+    AWal2 = 1700,
+    AWal3 = 1500,
+    AWal4 = 1700,
+    angleDegAziWin1 = -7,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -96,
+    Q_flowHea(displayUnit = "kW") = 580000,
+    Q_flowCoo(displayUnit = "kW") = -580000,
+    TSetHea = 291.65,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 2400000,
+    VHCBas = 1000000,
+    envelopeU = 0.6,
+    innerU = 1.2,
+    baseU = 0.6,
+    windowU = 4.1,
+    airchange = 0.4,
+    ratio = 0.4);
+  ParameterMap parameterMap11(
+    nFloors = 9,
+    heightBui = 29,
+    VBui = 97000,
+    ABuiGro = 3500,
+    AWal1 = 2000,
+    AWal2 = 3300,
+    AWal3 = 2000,
+    AWal4 = 3100,
+    angleDegAziWin1 = -5,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 175,
+    angleDegAziWin4 = -95,
+    Q_flowHea(displayUnit = "kW") = 1300000,
+    Q_flowCoo(displayUnit = "kW") = -1300000,
+    TSetHea = 296.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 1.4,
+    innerU = 1.2,
+    baseU = 2.5,
+    windowU = 3.4,
+    airchange = 0.5,
+    ratio = 0.6);
+  ParameterMap parameterMap12(
+    nFloors = 5,
+    heightBui = 11,
+    VBui = 47000,
+    ABuiGro = 4200,
+    AWal1 = 1600,
+    AWal2 = 1500,
+    AWal3 = 1400,
+    AWal4 = 1700,
+    angleDegAziWin1 = -6,
+    angleDegAziWin2 = 107,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -96,
+    Q_flowHea(displayUnit = "kW") = 750000,
+    Q_flowCoo(displayUnit = "kW") = -750000,
+    TSetHea = 292.05,
+    TSetCoo = 297.15,
+    VHCOut = 69000,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 1.2,
+    innerU = 1.2,
+    baseU = 0.7,
+    windowU = 3.5,
+    airchange = 0.4,
+    ratio = 0.2);
+  ParameterMap parameterMap13(
+    nFloors = 7,
+    heightBui = 28,
+    VBui = 390000,
+    ABuiGro = 14000,
+    AWal1 = 8400,
+    AWal2 = 3500,
+    AWal3 = 8000,
+    AWal4 = 3300,
+    angleDegAziWin1 = 6,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -96,
+    Q_flowHea(displayUnit = "kW") = 3000000,
+    Q_flowCoo(displayUnit = "kW") = -3000000,
+    TSetHea = 294.15,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 0.5,
+    innerU = 1.2,
+    baseU = 2.1,
+    windowU = 5.1,
+    airchange = 0.5,
+    ratio = 0.1);
+  ParameterMap parameterMap14(
+    nFloors = 9,
+    heightBui = 32,
+    VBui = 43000,
+    ABuiGro = 1300,
+    AWal1 = 890,
+    AWal2 = 2000,
+    AWal3 = 900,
+    AWal4 = 2100,
+    angleDegAziWin1 = -6,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -96,
+    Q_flowHea(displayUnit = "kW") = 390000,
+    Q_flowCoo(displayUnit = "kW") = -390000,
+    TSetHea = 292.65,
+    TSetCoo = 297.15,
+    VHCOut = 50000,
+    VHCInn = 100000,
+    VHCBas = 1000000,
+    envelopeU = 1.1,
+    innerU = 1.2,
+    baseU = 1.5,
+    windowU = 2.8,
+    airchange = 0.6,
+    ratio = 0.05);
+  ParameterMap parameterMap16(
+    nFloors = 7,
+    heightBui = 21,
+    VBui = 26000,
+    ABuiGro = 1300,
+    AWal1 = 880,
+    AWal2 = 1200,
+    AWal3 = 870,
+    AWal4 = 1200,
+    angleDegAziWin1 = -5,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -96,
+    Q_flowHea(displayUnit = "kW") = 480000,
+    Q_flowCoo(displayUnit = "kW") = -480000,
+    TSetHea = 296.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 1.8,
+    innerU = 1.2,
+    baseU = 2.5,
+    windowU = 5.4,
+    airchange = 0.6,
+    ratio = 0.5);
+  ParameterMap parameterMap17(
+    nFloors = 3,
+    heightBui = 10,
+    VBui = 17000,
+    ABuiGro = 1700,
+    AWal1 = 700,
+    AWal2 = 460,
+    AWal3 = 690,
+    AWal4 = 450,
+    angleDegAziWin1 = -6,
+    angleDegAziWin2 = 85,
+    angleDegAziWin3 = -175,
+    angleDegAziWin4 = -95,
+    Q_flowHea(displayUnit = "kW") = 300000,
+    Q_flowCoo(displayUnit = "kW") = -300000,
+    TSetHea = 295.85,
+    TSetCoo = 297.15,
+    VHCOut = 2300000,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 0.7,
+    innerU = 1.2,
+    baseU = 2.2,
+    windowU = 4.3,
+    airchange = 0.2,
+    ratio = 0.26);
+  ParameterMap parameterMap21(
+    nFloors = 3,
+    heightBui = 10,
+    VBui = 12000,
+    ABuiGro = 1140,
+    AWal1 = 490,
+    AWal2 = 940,
+    AWal3 = 470,
+    AWal4 = 980,
+    angleDegAziWin1 = -7,
+    angleDegAziWin2 = 97,
+    angleDegAziWin3 = 187,
+    angleDegAziWin4 = -97,
+    Q_flowHea(displayUnit = "kW") = 320000,
+    Q_flowCoo(displayUnit = "kW") = -320000,
+    TSetHea = 294.9,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 1200000,
+    VHCBas = 1000000,
+    envelopeU = 1,
+    innerU = 1.2,
+    baseU = 1.6,
+    windowU = 2.5,
+    airchange = 0.4,
+    ratio = 0.3);
+  ParameterMap parameterMap23(
+    nFloors = 5,
+    heightBui = 12,
+    VBui = 5700,
+    ABuiGro = 470,
+    AWal1 = 160,
+    AWal2 = 400,
+    AWal3 = 160,
+    AWal4 = 400,
+    angleDegAziWin1 = 20,
+    angleDegAziWin2 = 70,
+    angleDegAziWin3 = 161,
+    angleDegAziWin4 = -70,
+    Q_flowHea(displayUnit = "kW") = 370000,
+    Q_flowCoo(displayUnit = "kW") = -370000,
+    TSetHea = 296.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 1.6,
+    innerU = 1.2,
+    baseU = 2.5,
+    windowU = 4.4,
+    airchange = 0.6,
+    ratio = 0.4);
+  ParameterMap parameterMap25(
+    nFloors = 7,
+    heightBui = 23,
+    VBui = 130000,
+    ABuiGro = 5800,
+    AWal1 = 3700,
+    AWal2 = 3200,
+    AWal3 = 3500,
+    AWal4 = 3500,
+    angleDegAziWin1 = -2,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -87,
+    Q_flowHea(displayUnit = "kW") = 1700000,
+    Q_flowCoo(displayUnit = "kW") = -1700000,
+    TSetHea = 296.05,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 1.03,
+    innerU = 1.2,
+    baseU = 2.45,
+    windowU = 2.8,
+    airchange = 0.37,
+    ratio = 0.28);
+  ParameterMap parameterMap27(
+    nFloors = 3,
+    heightBui = 14,
+    VBui = 10000,
+    ABuiGro = 760,
+    AWal1 = 750,
+    AWal2 = 310,
+    AWal3 = 700,
+    AWal4 = 320,
+    angleDegAziWin1 = 37,
+    angleDegAziWin2 = 128,
+    angleDegAziWin3 = -143,
+    angleDegAziWin4 = -65,
+    Q_flowHea(displayUnit = "kW") = 150000,
+    Q_flowCoo(displayUnit = "kW") = -150000,
+    TSetHea = 293.95,
+    TSetCoo = 397.15,
+    VHCOut = 25000,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 0.8,
+    innerU = 1.2,
+    baseU = 1.9,
+    windowU = 2.6,
+    airchange = 0.4,
+    ratio = 0.26);
+  ParameterMap parameterMap29(
+    nFloors = 5,
+    heightBui = 16,
+    VBui = 10000,
+    ABuiGro = 640,
+    AWal1 = 530,
+    AWal2 = 380,
+    AWal3 = 530,
+    AWal4 = 410,
+    angleDegAziWin1 = 24,
+    angleDegAziWin2 = 115,
+    angleDegAziWin3 = -159,
+    angleDegAziWin4 = -66,
+    Q_flowHea(displayUnit = "kW") = 210000,
+    Q_flowCoo(displayUnit = "kW") = -210000,
+    TSetHea = 294.65,
+    TSetCoo = 297.15,
+    VHCOut = 50000,
+    VHCInn = 50000,
+    VHCBas = 1000000,
+    envelopeU = 1.4,
+    innerU = 1.2,
+    baseU = 1.8,
+    windowU = 2.5,
+    airchange = 0.6,
+    ratio = 0.3);
+  ParameterMap parameterMap30(
+    nFloors = 4,
+    heightBui = 23,
+    VBui = 170000,
+    ABuiGro = 7500,
+    AWal1 = 5200,
+    AWal2 = 1700,
+    AWal3 = 4900,
+    AWal4 = 2600,
+    angleDegAziWin1 = 50,
+    angleDegAziWin2 = 118,
+    angleDegAziWin3 = -150,
+    angleDegAziWin4 = -63,
+    Q_flowHea(displayUnit = "kW") = 3000000,
+    Q_flowCoo(displayUnit = "kW") = -3000000,
+    TSetHea = 296.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 2.4,
+    innerU = 1.2,
+    baseU = 2.5,
+    windowU = 6.0,
+    airchange = 0.9,
+    ratio = 0.4);
+  ParameterMap parameterMap33(
+    nFloors = 4,
+    heightBui = 14,
+    VBui = 22000,
+    ABuiGro = 1700,
+    AWal1 = 1300,
+    AWal2 = 710,
+    AWal3 = 1300,
+    AWal4 = 710,
+    angleDegAziWin1 = -6,
+    angleDegAziWin2 = 85,
+    angleDegAziWin3 = 175,
+    angleDegAziWin4 = -96,
+    Q_flowHea(displayUnit = "kW") = 51000,
+    Q_flowCoo(displayUnit = "kW") = -51000,
+    TSetHea = 290.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 0.5,
+    innerU = 1.2,
+    baseU = 0.5,
+    windowU = 2.5,
+    airchange = 0.2,
+    ratio = 0.05);
+  ParameterMap parameterMap34(
+    nFloors = 5,
+    heightBui = 18,
+    VBui = 67000,
+    ABuiGro = 3800,
+    AWal1 = 1700,
+    AWal2 = 2000,
+    AWal3 = 1700,
+    AWal4 = 2000,
+    angleDegAziWin1 = -6,
+    angleDegAziWin2 = 84,
+    angleDegAziWin3 = 174,
+    angleDegAziWin4 = -96,
+    Q_flowHea(displayUnit = "kW") = 1800000,
+    Q_flowCoo(displayUnit = "kW") = -1800000,
+    TSetHea = 294.65,
+    TSetCoo = 297.15,
+    VHCOut = 50000,
+    VHCInn = 25000,
+    VHCBas = 1000000,
+    envelopeU = 1.6,
+    innerU = 1.2,
+    baseU = 2.4,
+    windowU = 5.4,
+    airchange = 0.8,
+    ratio = 0.6);
+  ParameterMap parameterMap35(
+    nFloors = 22,
+    heightBui = 71,
+    VBui = 5800,
+    ABuiGro = 700,
+    AWal1 = 920,
+    AWal2 = 3600,
+    AWal3 = 920,
+    AWal4 = 3600,
+    angleDegAziWin1 = -5,
+    angleDegAziWin2 = 79,
+    angleDegAziWin3 = 175,
+    angleDegAziWin4 = -95,
+    Q_flowHea(displayUnit = "kW") = 690000,
+    Q_flowCoo(displayUnit = "kW") = -690000,
+    TSetHea = 296.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 2.5,
+    innerU = 1.2,
+    baseU = 2.5,
+    windowU = 5.4,
+    airchange = 0.27,
+    ratio = 0.6);
+  ParameterMap parameterMap39(
+    nFloors = 1,
+    heightBui = 5,
+    VBui = 33000,
+    ABuiGro = 6980,
+    AWal1 = 1700,
+    AWal2 = 470,
+    AWal3 = 1700,
+    AWal4 = 550,
+    angleDegAziWin1 = 17,
+    angleDegAziWin2 = 107,
+    angleDegAziWin3 = -163,
+    angleDegAziWin4 = -72,
+    Q_flowHea(displayUnit = "kW") = 780000,
+    Q_flowCoo(displayUnit = "kW") = -780000,
+    TSetHea = 293.15,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 260000,
+    VHCBas = 1000000,
+    envelopeU = 1.4,
+    innerU = 1.2,
+    baseU = 0.6,
+    windowU = 5.3,
+    airchange = 0.5,
+    ratio = 0.5);
+  ParameterMap parameterMap40(
+    nFloors = 2,
+    heightBui = 10,
+    VBui = 36000,
+    ABuiGro = 3600,
+    AWal1 = 1200,
+    AWal2 = 890,
+    AWal3 = 1100,
+    AWal4 = 880,
+    angleDegAziWin1 = -6,
+    angleDegAziWin2 = 85,
+    angleDegAziWin3 = 175,
+    angleDegAziWin4 = -96,
+    Q_flowHea(displayUnit = "kW") = 440000,
+    Q_flowCoo(displayUnit = "kW") = -440000,
+    TSetHea = 291.15,
+    TSetCoo = 397.15,
+    VHCOut = 50000,
+    VHCInn = 2000000,
+    VHCBas = 1000000,
+    envelopeU = 1.2,
+    innerU = 1.2,
+    baseU = 1.2,
+    windowU = 3.0,
+    airchange = 0.3,
+    ratio = 0.2);
+  ParameterMap parameterMap42(
+    nFloors = 2,
+    heightBui = 5,
+    VBui = 10000,
+    ABuiGro = 1900,
+    AWal1 = 350,
+    AWal2 = 340,
+    AWal3 = 310,
+    AWal4 = 340,
+    angleDegAziWin1 = 16,
+    angleDegAziWin2 = 107,
+    angleDegAziWin3 = -163,
+    angleDegAziWin4 = -72,
+    Q_flowHea(displayUnit = "kW") = 580000,
+    Q_flowCoo(displayUnit = "kW") = -580000,
+    TSetHea = 291.525,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 2200000,
+    VHCBas = 1000000,
+    envelopeU = 2.3,
+    innerU = 1.2,
+    baseU = 0.5,
+    windowU = 5.8,
+    airchange = 1.2,
+    ratio = 0.6);
+  ParameterMap parameterMap43(
+    nFloors = 5,
+    heightBui = 18,
+    VBui = 98000,
+    ABuiGro = 5600,
+    AWal1 = 1700,
+    AWal2 = 3500,
+    AWal3 = 1700,
+    AWal4 = 3500,
+    angleDegAziWin1 = 28,
+    angleDegAziWin2 = 118,
+    angleDegAziWin3 = -152,
+    angleDegAziWin4 = -62,
+    Q_flowHea(displayUnit = "kW") = 750000,
+    Q_flowCoo(displayUnit = "kW") = -750000,
+    TSetHea = 292.65,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 630000,
+    VHCBas = 1000000,
+    envelopeU = 1.0,
+    innerU = 1.2,
+    baseU = 1,
+    windowU = 4,
+    airchange = 0.2,
+    ratio = 0.3);
+  ParameterMap parameterMap44(
+    nFloors = 4,
+    heightBui = 13,
+    VBui = 75000,
+    ABuiGro = 5700,
+    AWal1 = 680,
+    AWal2 = 2300,
+    AWal3 = 650,
+    AWal4 = 2300,
+    angleDegAziWin1 = 28,
+    angleDegAziWin2 = 117,
+    angleDegAziWin3 = -153,
+    angleDegAziWin4 = -63,
+    Q_flowHea(displayUnit = "kW") = 1100000,
+    Q_flowCoo(displayUnit = "kW") = -1100000,
+    TSetHea = 292.65,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 13000,
+    VHCBas = 1000000,
+    envelopeU = 0.7,
+    innerU = 1.2,
+    baseU = 1.1,
+    windowU = 4.0,
+    airchange = 0.5,
+    ratio = 0.3);
+  ParameterMap parameterMap45(
+    nFloors = 3,
+    heightBui = 14,
+    VBui = 140000,
+    ABuiGro = 10000,
+    AWal1 = 4200,
+    AWal2 = 3200,
+    AWal3 = 5300,
+    AWal4 = 3100,
+    angleDegAziWin1 = 28,
+    angleDegAziWin2 = 118,
+    angleDegAziWin3 = -153,
+    angleDegAziWin4 = -63,
+    Q_flowHea(displayUnit = "kW") = 1700000,
+    Q_flowCoo(displayUnit = "kW") = -1700000,
+    TSetHea = 291.65,
+    TSetCoo = 397.15,
+    VHCOut = 2100000.0,
+    VHCInn = 860000.0,
+    VHCBas = 1000000,
+    envelopeU = 1,
+    innerU = 1.2,
+    baseU = 0.5,
+    windowU = 3.4,
+    airchange = 0.4,
+    ratio = 0.4);
+  ParameterMap parameterMap46(
+    nFloors = 4,
+    heightBui = 16,
+    VBui = 9700,
+    ABuiGro = 660,
+    AWal1 = 510,
+    AWal2 = 670,
+    AWal3 = 520,
+    AWal4 = 790,
+    angleDegAziWin1 = -40,
+    angleDegAziWin2 = 50,
+    angleDegAziWin3 = 140,
+    angleDegAziWin4 = -130,
+    Q_flowHea(displayUnit = "kW") = 58000,
+    Q_flowCoo(displayUnit = "kW") = -58000,
+    TSetHea = 291.525,
+    TSetCoo = 297.15,
+    VHCOut = 110000,
+    VHCInn = 1700000,
+    VHCBas = 1000000,
+    envelopeU = 0.6,
+    innerU = 1.2,
+    baseU = 0.5,
+    windowU = 3.6,
+    airchange = 0.2,
+    ratio = 0.1);
+  ParameterMap parameterMap47(
+    nFloors = 6,
+    heightBui = 21,
+    VBui = 32000,
+    ABuiGro = 1600,
+    AWal1 = 1700,
+    AWal2 = 970,
+    AWal3 = 1200,
+    AWal4 = 1600,
+    angleDegAziWin1 = -6,
+    angleDegAziWin2 = 100,
+    angleDegAziWin3 = -149,
+    angleDegAziWin4 = -69,
+    Q_flowHea(displayUnit = "kW") = 360000,
+    Q_flowCoo(displayUnit = "kW") = -360000,
+    TSetHea = 292.55627,
+    TSetCoo = 297.15,
+    VHCOut = 710000,
+    VHCInn = 2100000,
+    VHCBas = 1000000,
+    envelopeU = 1,
+    innerU = 1.2,
+    baseU = 1,
+    windowU = 4,
+    airchange = 0.2,
+    ratio = 0.5);
+  ParameterMap parameterMap48(
+    nFloors = 5,
+    heightBui = 20,
+    VBui = 100000,
+    ABuiGro = 5100,
+    AWal1 = 850,
+    AWal2 = 2300,
+    AWal3 = 850,
+    AWal4 = 2300,
+    angleDegAziWin1 = 25,
+    angleDegAziWin2 = 64,
+    angleDegAziWin3 = -155,
+    angleDegAziWin4 = -64,
+    Q_flowHea(displayUnit = "kW") = 760000,
+    Q_flowCoo(displayUnit = "kW") = -760000,
+    TSetHea = 296.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 0.6,
+    innerU = 1.2,
+    baseU = 2.5,
+    windowU = 3.5,
+    airchange = 0.4,
+    ratio = 0.1);
+  ParameterMap parameterMap50(
+    nFloors = 4,
+    heightBui = 15,
+    VBui = 70000,
+    ABuiGro = 4600,
+    AWal1 = 1400,
+    AWal2 = 1400,
+    AWal3 = 2300,
+    AWal4 = 1400,
+    angleDegAziWin1 = 28,
+    angleDegAziWin2 = 118,
+    angleDegAziWin3 = -152,
+    angleDegAziWin4 = -63,
+    Q_flowHea(displayUnit = "kW") = 1200000,
+    Q_flowCoo(displayUnit = "kW") = -1200000,
+    TSetHea = 293.65,
+    TSetCoo = 297.15,
+    VHCOut = 2400000,
+    VHCInn = 2400000,
+    VHCBas = 1000000,
+    envelopeU = 1.2,
+    innerU = 1.2,
+    baseU = 1.4,
+    windowU = 6.0,
+    airchange = 0.6,
+    ratio = 0.3);
+  ParameterMap parameterMap51(
+    nFloors = 2,
+    heightBui = 8,
+    VBui = 34000,
+    ABuiGro = 4300,
+    AWal1 = 1300,
+    AWal2 = 1900,
+    AWal3 = 1400,
+    AWal4 = 1900,
+    angleDegAziWin1 = 20,
+    angleDegAziWin2 = 110,
+    angleDegAziWin3 = -159,
+    angleDegAziWin4 = -70,
+    Q_flowHea(displayUnit = "kW") = 720000,
+    Q_flowCoo(displayUnit = "kW") = -720000,
+    TSetHea = 296.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 1700000,
+    VHCBas = 1000000,
+    envelopeU = 0.5,
+    innerU = 1.2,
+    baseU = 2.5,
+    windowU = 2.5,
+    airchange = 0.51,
+    ratio = 0.14);
+  ParameterMap parameterMap52(
+    nFloors = 3,
+    heightBui = 9,
+    VBui = 44000,
+    ABuiGro = 5400,
+    AWal1 = 940,
+    AWal2 = 2500,
+    AWal3 = 900,
+    AWal4 = 2500,
+    angleDegAziWin1 = 22,
+    angleDegAziWin2 = 113,
+    angleDegAziWin3 = -158,
+    angleDegAziWin4 = -68,
+    Q_flowHea(displayUnit = "kW") = 580000,
+    Q_flowCoo(displayUnit = "kW") = -580000,
+    TSetHea = 292.65,
+    TSetCoo = 297.15,
+    VHCOut = 38000,
+    VHCInn = 50000,
+    VHCBas = 1000000,
+    envelopeU = 0.8,
+    innerU = 1.2,
+    baseU = 1.2,
+    windowU = 3.9,
+    airchange = 0.4,
+    ratio = 0.2);
+  ParameterMap parameterMap53(
+    nFloors = 4,
+    heightBui = 12,
+    VBui = 47000,
+    ABuiGro = 4100,
+    AWal1 = 1900,
+    AWal2 = 840,
+    AWal3 = 2000,
+    AWal4 = 980.0,
+    angleDegAziWin1 = 28,
+    angleDegAziWin2 = 117,
+    angleDegAziWin3 = -152,
+    angleDegAziWin4 = -63,
+    Q_flowHea(displayUnit = "kW") = 790000,
+    Q_flowCoo(displayUnit = "kW") = -790000,
+    TSetHea = 293.65,
+    TSetCoo = 297.15,
+    VHCOut = 13000,
+    VHCInn = 6300,
+    VHCBas = 1000000,
+    envelopeU = 1.6,
+    innerU = 1.2,
+    baseU = 1.6,
+    windowU = 5.5,
+    airchange = 0.6,
+    ratio = 0.4);
+  ParameterMap parameterMap54(
+    nFloors = 2,
+    heightBui = 8,
+    VBui = 12000,
+    ABuiGro = 1500,
+    AWal1 = 440,
+    AWal2 = 860,
+    AWal3 = 420,
+    AWal4 = 870,
+    angleDegAziWin1 = 24,
+    angleDegAziWin2 = 113,
+    angleDegAziWin3 = -156,
+    angleDegAziWin4 = -65,
+    Q_flowHea(displayUnit = "kW") = 250000,
+    Q_flowCoo(displayUnit = "kW") = -250000,
+    TSetHea = 291.65,
+    TSetCoo = 397.15,
+    VHCOut = 2400000,
+    VHCInn = 2400000,
+    VHCBas = 1000000,
+    envelopeU = 0.8,
+    innerU = 1.2,
+    baseU = 0.73,
+    windowU = 5.94,
+    airchange = 0.71,
+    ratio = 0.3);
+  ParameterMap parameterMap55(
+    nFloors = 9,
+    heightBui = 30,
+    VBui = 56000,
+    ABuiGro = 1900,
+    AWal1 = 2500,
+    AWal2 = 1000,
+    AWal3 = 2500,
+    AWal4 = 1000,
+    angleDegAziWin1 = -6,
+    angleDegAziWin2 = 85,
+    angleDegAziWin3 = 175,
+    angleDegAziWin4 = -95,
+    Q_flowHea(displayUnit = "kW") = 290000,
+    Q_flowCoo(displayUnit = "kW") = -290000,
+    TSetHea = 290.15,
+    TSetCoo = 297.15,
+    VHCOut = 6300,
+    VHCInn = 490000,
+    VHCBas = 1000000,
+    envelopeU = 0.5,
+    innerU = 1.2,
+    baseU = 0.85,
+    windowU = 2.5,
+    airchange = 0.2,
+    ratio = 0.05);
+
+  BuildingSystems.Buildings.Ambience ambience(
+    nSurfaces=342,
+    redeclare block WeatherData =
+        BuildingSystems.Climate.WeatherDataMeteonorm.Germany_Berlin_Meteonorm_ASCII)
+    annotation (Placement(transformation(extent={{162,194},{262,294}})));
+  Building building1(nZones=1, parameterMap = parameterMap1, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-182,30},{-162,50}})));
+  Building building2(nZones=1, parameterMap = parameterMap2, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-156,-162},{-136,-142}})));
+  Building building3(nZones=1, parameterMap = parameterMap3, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-142,-142},{-122,-122}})));
+  Building building5(nZones=1, parameterMap = parameterMap5, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-102,88},{-82,108}})));
+  Building building6(nZones=1, parameterMap = parameterMap6, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-204,-122},{-184,-102}})));
+  Building building7(nZones=1, parameterMap = parameterMap7, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{104,-86},{124,-66}})));
+  Building building8(nZones=1, parameterMap = parameterMap8, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-60,116},{-40,136}})));
+  Building building9(nZones=1, parameterMap = parameterMap9, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-138,-96},{-118,-76}})));
+  Building building10(nZones=1, parameterMap = parameterMap10, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-16,58},{4,78}})));
+  Building building11(nZones=1, parameterMap = parameterMap11, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-24,128},{-4,148}})));
+  Building building12(nZones=1, parameterMap = parameterMap12, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-182,122},{-162,142}})));
+  Building building13(nZones=1, parameterMap = parameterMap13, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-14,-104},{6,-84}})));
+  Building building14(nZones=1, parameterMap = parameterMap14, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-72,74},{-52,94}})));
+  Building building16(nZones=1, parameterMap = parameterMap16, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-64,178},{-44,198}})));
+  Building building17(nZones=1, parameterMap = parameterMap17, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-166,78},{-146,98}})));
+  Building building21(nZones=1, parameterMap = parameterMap21, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-142,188},{-122,208}})));
+  Building building23(nZones=1, parameterMap = parameterMap23, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{280,-152},{300,-132}})));
+  Building building25(nZones=1, parameterMap = parameterMap25, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-62,34},{-42,54}})));
+  Building building27(nZones=1, parameterMap = parameterMap27, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{46,58},{66,78}})));
+  Building building29(nZones=1, parameterMap = parameterMap29, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{98,-134},{118,-114}})));
+  Building building30(nZones=1, parameterMap = parameterMap30, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-120,-216},{-100,-196}})));
+  Building building33(nZones=1, parameterMap = parameterMap33, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-86,208},{-66,228}})));
+  Building building34(nZones=1, parameterMap = parameterMap34, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{18,20},{38,40}})));
+  Building building35(nZones=1, parameterMap = parameterMap35, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-346,-36},{-326,-16}})));
+  Building building39(nZones=1, parameterMap = parameterMap39, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{288,-80},{308,-60}})));
+  Building building40(nZones=1, parameterMap = parameterMap40, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-130,16},{-110,36}})));
+  Building building43(nZones=1, parameterMap = parameterMap43, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-240,292},{-220,312}})));
+  Building building44(nZones=1, parameterMap = parameterMap44, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{54,-314},{74,-294}})));
+  Building building45(nZones=1, parameterMap = parameterMap45, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-12,-310},{8,-290}})));
+  Building building46(nZones=1, parameterMap = parameterMap46, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-186,-164},{-166,-144}})));
+  Building building47(nZones=1, parameterMap = parameterMap47, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{78,28},{98,48}})));
+  Building building48(nZones=1, parameterMap = parameterMap48, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{158,-230},{178,-210}})));
+  Building building50(nZones=1, parameterMap = parameterMap50, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-116,-170},{-96,-150}})));
+  Building building51(nZones=1, parameterMap = parameterMap51, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{236,-140},{256,-120}})));
+  Building building52(nZones=1, parameterMap = parameterMap52, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{128,-160},{148,-140}})));
+  Building building53(nZones=1, parameterMap = parameterMap53, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{58,-210},{78,-190}})));
+  Building building54(nZones=1, parameterMap = parameterMap54, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{82,-174},{102,-154}})));
+  Building building55(nZones=1, parameterMap = parameterMap55, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-286,84},{-266,104}})));
+  Modelica.Blocks.Sources.Constant set_airchange(
+    k=building43.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-200,292},{-208,300}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling(
+    k=building43.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-200,304},{-208,312}})));
+  Modelica.Blocks.Sources.Constant t_set_heating(
+    k=building43.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-200,316},{-208,324}})));
+  Modelica.Blocks.Sources.Constant set_airchange1(
+    k=building33.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-46,208},{-54,216}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling1(
+    k=building33.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-46,220},{-54,228}})));
+  Modelica.Blocks.Sources.Constant t_set_heating1(
+    k=building33.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-46,232},{-54,240}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling2(
+    k=building21.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-102,200},{-110,208}})));
+  Modelica.Blocks.Sources.Constant t_set_heating2(
+    k=building21.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-102,212},{-110,220}})));
+  Modelica.Blocks.Sources.Constant set_airchange2(
+    k=building21.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-102,188},{-110,196}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling3(
+    k=building16.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-24,190},{-32,198}})));
+  Modelica.Blocks.Sources.Constant t_set_heating3(
+    k=building16.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-24,202},{-32,210}})));
+  Modelica.Blocks.Sources.Constant set_airchange3(
+     k=building16.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-24,178},{-32,186}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling4(
+    k=building11.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{16,140},{8,148}})));
+  Modelica.Blocks.Sources.Constant t_set_heating4(
+    k=building11.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{16,152},{8,160}})));
+  Modelica.Blocks.Sources.Constant set_airchange4(
+    k=building11.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{16,128},{8,136}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling5(
+    k=building12.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-144,134},{-152,142}})));
+  Modelica.Blocks.Sources.Constant t_set_heating5(
+    k=building12.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-144,146},{-152,154}})));
+  Modelica.Blocks.Sources.Constant set_airchange5(
+    k=building12.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-144,122},{-152,130}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling6(
+    k=building55.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-246,96},{-254,104}})));
+  Modelica.Blocks.Sources.Constant t_set_heating6(
+    k=building55.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-246,108},{-254,116}})));
+  Modelica.Blocks.Sources.Constant set_airchange6(
+    k=building55.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-246,84},{-254,92}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling7(
+    k=building35.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-306,-24},{-314,-16}})));
+  Modelica.Blocks.Sources.Constant t_set_heating7(
+    k=building35.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-306,-12},{-314,-4}})));
+  Modelica.Blocks.Sources.Constant set_airchange7(
+    k=building35.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-306,-36},{-314,-28}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling8(
+    k=building27.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{86,70},{78,78}})));
+  Modelica.Blocks.Sources.Constant t_set_heating8(
+    k=building27.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{86,82},{78,90}})));
+  Modelica.Blocks.Sources.Constant set_airchange8(
+    k=building27.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{86,58},{78,66}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling9(
+    k=building47.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{118,40},{110,48}})));
+  Modelica.Blocks.Sources.Constant t_set_heating9(
+    k=building47.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{118,52},{110,60}})));
+  Modelica.Blocks.Sources.Constant set_airchange9(
+    k=building47.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{118,28},{110,36}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling10(
+    k=building34.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{58,32},{50,40}})));
+  Modelica.Blocks.Sources.Constant t_set_heating10(
+    k=building34.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{58,44},{50,52}})));
+  Modelica.Blocks.Sources.Constant set_airchange10(
+    k=building34.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{58,20},{50,28}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling11(
+    k=building10.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{24,70},{16,78}})));
+  Modelica.Blocks.Sources.Constant t_set_heating11(
+    k=building10.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{24,82},{16,90}})));
+  Modelica.Blocks.Sources.Constant set_airchange11(
+    k=building10.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{24,58},{16,66}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling12(
+    k=building14.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-32,86},{-40,94}})));
+  Modelica.Blocks.Sources.Constant t_set_heating12(
+    k=building14.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-32,98},{-40,106}})));
+  Modelica.Blocks.Sources.Constant set_airchange12(
+    k=building14.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-32,74},{-40,82}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling13(
+    k=building17.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-126,90},{-134,98}})));
+  Modelica.Blocks.Sources.Constant t_set_heating13(
+    k=building17.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-126,102},{-134,110}})));
+  Modelica.Blocks.Sources.Constant set_airchange13(
+    k=building17.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-126,78},{-134,86}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling14(
+    k=building39.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{328,-68},{320,-60}})));
+  Modelica.Blocks.Sources.Constant t_set_heating14(
+    k=building39.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{328,-56},{320,-48}})));
+  Modelica.Blocks.Sources.Constant set_airchange14(
+    k=building39.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{328,-80},{320,-72}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling15(
+    k=building51.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{276,-128},{268,-120}})));
+  Modelica.Blocks.Sources.Constant t_set_heating15(
+    k=building51.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{276,-116},{268,-108}})));
+  Modelica.Blocks.Sources.Constant set_airchange15(
+    k=building51.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{276,-140},{268,-132}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling16(
+    k=building23.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{320,-140},{312,-132}})));
+  Modelica.Blocks.Sources.Constant t_set_heating16(
+    k=building23.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{320,-128},{312,-120}})));
+  Modelica.Blocks.Sources.Constant set_airchange16(
+    k=building23.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{320,-152},{312,-144}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling17(
+    k=building8.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-26,132},{-34,140}})));
+  Modelica.Blocks.Sources.Constant t_set_heating17(
+    k=building8.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-26,144},{-34,152}})));
+  Modelica.Blocks.Sources.Constant set_airchange17(
+    k=building8.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-26,120},{-34,128}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling18(
+    k=building5.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-70,106},{-78,114}})));
+  Modelica.Blocks.Sources.Constant t_set_heating18(
+    k=building5.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-70,118},{-78,126}})));
+  Modelica.Blocks.Sources.Constant set_airchange18(
+    k=building5.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-70,94},{-78,102}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling19(
+    k=building25.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-22,46},{-30,54}})));
+  Modelica.Blocks.Sources.Constant t_set_heating19(
+    k=building25.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-22,58},{-30,66}})));
+  Modelica.Blocks.Sources.Constant set_airchange19(
+    k=building25.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-22,34},{-30,42}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling20(
+    k=building40.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-90,28},{-98,36}})));
+  Modelica.Blocks.Sources.Constant t_set_heating20(
+    k=building40.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-90,40},{-98,48}})));
+  Modelica.Blocks.Sources.Constant set_airchange20(
+    k=building40.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-90,16},{-98,24}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling21(
+    k=building1.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-142,42},{-150,50}})));
+  Modelica.Blocks.Sources.Constant t_set_heating21(
+    k=building1.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-142,54},{-150,62}})));
+  Modelica.Blocks.Sources.Constant set_airchange21(
+    k=building1.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-142,30},{-150,38}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling22(
+    k=building9.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-98,-84},{-106,-76}})));
+  Modelica.Blocks.Sources.Constant t_set_heating22(
+    k=building9.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-98,-72},{-106,-64}})));
+  Modelica.Blocks.Sources.Constant set_airchange22(
+    k=building9.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-98,-96},{-106,-88}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling23(
+    k=building13.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{26,-92},{18,-84}})));
+  Modelica.Blocks.Sources.Constant t_set_heating23(
+    k=building13.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{26,-80},{18,-72}})));
+  Modelica.Blocks.Sources.Constant set_airchange23(
+    k=building13.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{26,-104},{18,-96}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling24(
+    k=building6.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-160,-110},{-168,-102}})));
+  Modelica.Blocks.Sources.Constant t_set_heating24(
+    k=building6.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-160,-98},{-168,-90}})));
+  Modelica.Blocks.Sources.Constant set_airchange24(
+    k=building6.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-160,-122},{-168,-114}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling25(
+    k=building46.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-156,-148},{-164,-140}})));
+  Modelica.Blocks.Sources.Constant t_set_heating25(
+    k=building46.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-156,-136},{-164,-128}})));
+  Modelica.Blocks.Sources.Constant set_airchange25(
+    k=building46.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-156,-160},{-164,-152}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling26(
+    k=building3.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-102,-130},{-110,-122}})));
+  Modelica.Blocks.Sources.Constant t_set_heating26(
+    k=building3.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-102,-118},{-110,-110}})));
+  Modelica.Blocks.Sources.Constant set_airchange26(
+    k=building3.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-102,-142},{-110,-134}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling27(
+    k=building50.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-76,-160},{-84,-152}})));
+  Modelica.Blocks.Sources.Constant t_set_heating27(
+    k=building50.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-76,-148},{-84,-140}})));
+  Modelica.Blocks.Sources.Constant set_airchange27(
+    k=building50.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-76,-172},{-84,-164}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling28(
+    k=building2.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-118,-168},{-126,-160}})));
+  Modelica.Blocks.Sources.Constant t_set_heating28(
+    k=building2.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-118,-156},{-126,-148}})));
+  Modelica.Blocks.Sources.Constant set_airchange28(
+    k=building2.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-118,-180},{-126,-172}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling29(
+    k=building30.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{-80,-204},{-88,-196}})));
+  Modelica.Blocks.Sources.Constant t_set_heating29(
+    k=building30.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{-80,-192},{-88,-184}})));
+  Modelica.Blocks.Sources.Constant set_airchange29(
+    k=building30.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{-80,-216},{-88,-208}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling30(
+    k=building7.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{144,-74},{136,-66}})));
+  Modelica.Blocks.Sources.Constant t_set_heating30(
+    k=building7.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{144,-62},{136,-54}})));
+  Modelica.Blocks.Sources.Constant set_airchange30(
+    k=building7.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{144,-86},{136,-78}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling31(
+    k=building29.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{138,-122},{130,-114}})));
+  Modelica.Blocks.Sources.Constant t_set_heating31(
+    k=building29.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{138,-110},{130,-102}})));
+  Modelica.Blocks.Sources.Constant set_airchange31(
+    k=building29.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{138,-134},{130,-126}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling32(
+    k=building52.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{168,-148},{160,-140}})));
+  Modelica.Blocks.Sources.Constant t_set_heating32(
+    k=building52.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{168,-136},{160,-128}})));
+  Modelica.Blocks.Sources.Constant set_airchange32(
+    k=building52.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{168,-160},{160,-152}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling33(
+    k=building54.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{122,-162},{114,-154}})));
+  Modelica.Blocks.Sources.Constant t_set_heating33(
+    k=building54.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{122,-150},{114,-142}})));
+  Modelica.Blocks.Sources.Constant set_airchange33(
+    k=building54.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{122,-174},{114,-166}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling34(
+    k=building53.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{98,-198},{90,-190}})));
+  Modelica.Blocks.Sources.Constant t_set_heating34(
+    k=building53.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{98,-186},{90,-178}})));
+  Modelica.Blocks.Sources.Constant set_airchange34(
+    k=building53.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{98,-210},{90,-202}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling35(
+    k=building48.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{198,-218},{190,-210}})));
+  Modelica.Blocks.Sources.Constant t_set_heating35(
+    k=building48.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{198,-206},{190,-198}})));
+  Modelica.Blocks.Sources.Constant set_airchange35(
+    k=building48.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{198,-230},{190,-222}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling36(
+    k=building45.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{28,-298},{20,-290}})));
+  Modelica.Blocks.Sources.Constant t_set_heating36(
+    k=building45.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{28,-286},{20,-278}})));
+  Modelica.Blocks.Sources.Constant set_airchange36(
+    k=building45.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{28,-310},{20,-302}})));
+  Modelica.Blocks.Sources.Constant t_set_cooling37(
+    k=building44.parameterMap.TSetCoo)
+    annotation (Placement(transformation(extent={{94,-302},{86,-294}})));
+  Modelica.Blocks.Sources.Constant t_set_heating37(
+    k=building44.parameterMap.TSetHea)
+    annotation (Placement(transformation(extent={{94,-290},{86,-282}})));
+  Modelica.Blocks.Sources.Constant set_airchange37(
+    k=building44.parameterMap.airchange)
+    annotation (Placement(transformation(extent={{94,-314},{86,-306}})));
+  Modelica.Units.SI.HeatFlowRate Q_flowHea;
+  Modelica.Units.SI.HeatFlowRate Q_flowCoo;
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding45(T=283.15)
+    annotation (Placement(transformation(extent={{-10,-320},{-2,-312}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding44(T=283.15)
+    annotation (Placement(transformation(extent={{56,-324},{64,-316}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding23(T=283.15)
+    annotation (Placement(transformation(extent={{282,-162},{290,-154}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding51(T=283.15)
+    annotation (Placement(transformation(extent={{238,-150},{246,-142}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding39(T=283.15)
+    annotation (Placement(transformation(extent={{290,-90},{298,-82}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding13(T=283.15)
+    annotation (Placement(transformation(extent={{-12,-114},{-4,-106}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding7(T=283.15)
+    annotation (Placement(transformation(extent={{106,-96},{114,-88}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding29(T=283.15)
+    annotation (Placement(transformation(extent={{100,-144},{108,-136}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding52(T=283.15)
+    annotation (Placement(transformation(extent={{130,-170},{138,-162}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding54(T=283.15)
+    annotation (Placement(transformation(extent={{68,-184},{76,-176}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding53(T=283.15)
+    annotation (Placement(transformation(extent={{60,-220},{68,-212}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding9(T=283.15)
+    annotation (Placement(transformation(extent={{-136,-106},{-128,-98}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding6(T=283.15)
+    annotation (Placement(transformation(extent={{-202,-132},{-194,-124}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding2(T=283.15)
+    annotation (Placement(transformation(extent={{-154,-172},{-146,-164}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding46(T=283.15)
+    annotation (Placement(transformation(extent={{-184,-174},{-176,-166}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding50(T=283.15)
+    annotation (Placement(transformation(extent={{-114,-180},{-106,-172}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding30(T=283.15)
+    annotation (Placement(transformation(extent={{-118,-226},{-110,-218}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding3(T=283.15)
+    annotation (Placement(transformation(extent={{-142,-174},{-134,-166}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding35(T=283.15)
+    annotation (Placement(transformation(extent={{-344,-46},{-336,-38}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding55(T=283.15)
+    annotation (Placement(transformation(extent={{-284,74},{-276,82}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding43(T=283.15)
+    annotation (Placement(transformation(extent={{-238,282},{-230,290}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding21(T=283.15)
+    annotation (Placement(transformation(extent={{-140,178},{-132,186}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding33(T=283.15)
+    annotation (Placement(transformation(extent={{-84,198},{-76,206}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding16(T=283.15)
+    annotation (Placement(transformation(extent={{-62,168},{-54,176}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding12(T=283.15)
+    annotation (Placement(transformation(extent={{-180,112},{-172,120}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding8(T=283.15)
+    annotation (Placement(transformation(extent={{-58,106},{-50,114}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding11(T=283.15)
+    annotation (Placement(transformation(extent={{-22,118},{-14,126}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding17(T=283.15)
+    annotation (Placement(transformation(extent={{-164,68},{-156,76}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding5(T=283.15)
+    annotation (Placement(transformation(extent={{-100,78},{-92,86}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding14(T=283.15)
+    annotation (Placement(transformation(extent={{-70,64},{-62,72}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding1(T=283.15)
+    annotation (Placement(transformation(extent={{-180,20},{-172,28}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding40(T=283.15)
+    annotation (Placement(transformation(extent={{-128,6},{-120,14}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding25(T=283.15)
+    annotation (Placement(transformation(extent={{-60,24},{-52,32}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding10(T=283.15)
+    annotation (Placement(transformation(extent={{-14,48},{-6,56}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding34(T=283.15)
+    annotation (Placement(transformation(extent={{20,10},{28,18}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding27(T=283.15)
+    annotation (Placement(transformation(extent={{34,48},{42,56}})));
+  Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding47(T=283.15)
+    annotation (Placement(transformation(extent={{80,18},{88,26}})));
+equation
+
+  der(Q_district) = Q_flowHea;
+
+  Q_flowHea = building1.Q_flow_heating[1] + building2.Q_flow_heating[1] + building3.Q_flow_heating[1] + building5.Q_flow_heating[1] + building6.Q_flow_heating[1] + building7.Q_flow_heating[1] + building8.Q_flow_heating[1] + building9.Q_flow_heating[1] + building10.Q_flow_heating[1] + building11.Q_flow_heating[1] + building12.Q_flow_heating[1] + building13.Q_flow_heating[1] +
+              building14.Q_flow_heating[1] + building16.Q_flow_heating[1] + building17.Q_flow_heating[1] + building21.Q_flow_heating[1] + building23.Q_flow_heating[1] + building25.Q_flow_heating[1] + building27.Q_flow_heating[1] + building29.Q_flow_heating[1] + building30.Q_flow_heating[1] + building33.Q_flow_heating[1] + building34.Q_flow_heating[1] + building35.Q_flow_heating[1] + building39.Q_flow_heating[1] +
+              building40.Q_flow_heating[1] + building43.Q_flow_heating[1] + building44.Q_flow_heating[1] + building45.Q_flow_heating[1] + building46.Q_flow_heating[1] + building47.Q_flow_heating[1] + building48.Q_flow_heating[1] + building50.Q_flow_heating[1] + building51.Q_flow_heating[1] + building52.Q_flow_heating[1] +
+              building53.Q_flow_heating[1] + building54.Q_flow_heating[1] + building55.Q_flow_heating[1];
+  Q_flowCoo = building1.Q_flow_cooling[1] + building2.Q_flow_cooling[1] + building3.Q_flow_cooling[1] + building5.Q_flow_cooling[1] + building6.Q_flow_cooling[1] + building7.Q_flow_cooling[1] + building8.Q_flow_cooling[1] + building9.Q_flow_cooling[1] + building10.Q_flow_cooling[1] + building11.Q_flow_cooling[1] + building12.Q_flow_cooling[1] + building13.Q_flow_cooling[1] +
+              building14.Q_flow_cooling[1] + building16.Q_flow_cooling[1] + building17.Q_flow_cooling[1] + building21.Q_flow_cooling[1] + building23.Q_flow_cooling[1] + building25.Q_flow_cooling[1] + building27.Q_flow_cooling[1] + building29.Q_flow_cooling[1] + building30.Q_flow_cooling[1] + building33.Q_flow_cooling[1] + building34.Q_flow_cooling[1] + building35.Q_flow_cooling[1] + building39.Q_flow_cooling[1] +
+              building40.Q_flow_cooling[1] + building43.Q_flow_cooling[1] + building44.Q_flow_cooling[1] + building45.Q_flow_cooling[1] + building46.Q_flow_cooling[1] + building47.Q_flow_cooling[1] + building48.Q_flow_cooling[1] + building50.Q_flow_cooling[1] + building51.Q_flow_cooling[1] + building52.Q_flow_cooling[1] +
+              building53.Q_flow_cooling[1] + building54.Q_flow_cooling[1] + building55.Q_flow_cooling[1];
+
+  connect(ambience.toSurfacePorts[1:9], building1.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[10:18], building2.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[19:27], building3.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[28:36], building5.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[334:342], building6.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[37:45], building7.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[46:54], building8.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[55:63], building9.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[64:72], building10.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[73:81], building11.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[82:90], building12.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[91:99], building13.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[100:108], building14.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[109:117], building16.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[118:126], building17.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[127:135], building21.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[136:144], building23.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[145:153], building25.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[154:162], building27.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[163:171], building29.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[172:180], building30.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[181:189], building33.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[190:198], building34.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[199:207], building35.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[208:216], building39.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[217:225], building40.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[226:234], building43.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[235:243], building44.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[244:252], building45.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[253:261], building46.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[262:270], building47.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[271:279], building48.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[280:288], building50.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[289:297], building51.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[298:306], building52.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[307:315], building53.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[316:324], building54.toAmbienceSurfacesPorts);
+  connect(ambience.toSurfacePorts[325:333], building55.toAmbienceSurfacesPorts);
+
+  connect(ambience.toAirPorts[1:9], building1.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[10:18], building2.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[19:27], building3.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[28:36], building5.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[334:342], building6.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[37:45], building7.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[46:54], building8.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[55:63], building9.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[64:72], building10.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[73:81], building11.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[82:90], building12.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[91:99], building13.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[100:108], building14.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[109:117], building16.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[118:126], building17.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[127:135], building21.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[136:144], building23.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[145:153], building25.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[154:162], building27.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[163:171], building29.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[172:180], building30.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[181:189], building33.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[190:198], building34.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[199:207], building35.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[208:216], building39.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[217:225], building40.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[226:234], building43.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[235:243], building44.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[244:252], building45.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[253:261], building46.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[262:270], building47.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[271:279], building48.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[280:288], building50.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[289:297], building51.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[298:306], building52.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[307:315], building53.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[316:324], building54.toAmbienceAirPorts);
+  connect(ambience.toAirPorts[325:333], building55.toAmbienceAirPorts);
+
+  connect(ambience.TAirRef, building1.TAirAmb);
+  connect(ambience.TAirRef, building2.TAirAmb);
+  connect(ambience.TAirRef, building3.TAirAmb);
+  connect(ambience.TAirRef, building5.TAirAmb);
+  connect(ambience.TAirRef, building6.TAirAmb);
+  connect(ambience.TAirRef, building7.TAirAmb);
+  connect(ambience.TAirRef, building8.TAirAmb);
+  connect(ambience.TAirRef, building9.TAirAmb);
+  connect(ambience.TAirRef, building10.TAirAmb);
+  connect(ambience.TAirRef, building11.TAirAmb);
+  connect(ambience.TAirRef, building12.TAirAmb);
+  connect(ambience.TAirRef, building13.TAirAmb);
+  connect(ambience.TAirRef, building14.TAirAmb);
+  connect(ambience.TAirRef, building16.TAirAmb);
+  connect(ambience.TAirRef, building17.TAirAmb);
+  connect(ambience.TAirRef, building21.TAirAmb);
+  connect(ambience.TAirRef, building23.TAirAmb);
+  connect(ambience.TAirRef, building25.TAirAmb);
+  connect(ambience.TAirRef, building27.TAirAmb);
+  connect(ambience.TAirRef, building29.TAirAmb);
+  connect(ambience.TAirRef, building30.TAirAmb);
+  connect(ambience.TAirRef, building33.TAirAmb);
+  connect(ambience.TAirRef, building34.TAirAmb);
+  connect(ambience.TAirRef, building35.TAirAmb);
+  connect(ambience.TAirRef, building39.TAirAmb);
+  connect(ambience.TAirRef, building40.TAirAmb);
+  connect(ambience.TAirRef, building43.TAirAmb);
+  connect(ambience.TAirRef, building44.TAirAmb);
+  connect(ambience.TAirRef, building45.TAirAmb);
+  connect(ambience.TAirRef, building46.TAirAmb);
+  connect(ambience.TAirRef, building47.TAirAmb);
+  connect(ambience.TAirRef, building48.TAirAmb);
+  connect(ambience.TAirRef, building50.TAirAmb);
+  connect(ambience.TAirRef, building51.TAirAmb);
+  connect(ambience.TAirRef, building52.TAirAmb);
+  connect(ambience.TAirRef, building53.TAirAmb);
+  connect(ambience.TAirRef, building54.TAirAmb);
+  connect(ambience.TAirRef, building55.TAirAmb);
+
+  connect(ambience.xAir, building1.xAirAmb);
+  connect(ambience.xAir, building2.xAirAmb);
+  connect(ambience.xAir, building3.xAirAmb);
+  connect(ambience.xAir, building5.xAirAmb);
+  connect(ambience.xAir, building6.xAirAmb);
+  connect(ambience.xAir, building7.xAirAmb);
+  connect(ambience.xAir, building8.xAirAmb);
+  connect(ambience.xAir, building9.xAirAmb);
+  connect(ambience.xAir, building10.xAirAmb);
+  connect(ambience.xAir, building11.xAirAmb);
+  connect(ambience.xAir, building12.xAirAmb);
+  connect(ambience.xAir, building13.xAirAmb);
+  connect(ambience.xAir, building14.xAirAmb);
+  connect(ambience.xAir, building16.xAirAmb);
+  connect(ambience.xAir, building17.xAirAmb);
+  connect(ambience.xAir, building21.xAirAmb);
+  connect(ambience.xAir, building23.xAirAmb);
+  connect(ambience.xAir, building25.xAirAmb);
+  connect(ambience.xAir, building27.xAirAmb);
+  connect(ambience.xAir, building29.xAirAmb);
+  connect(ambience.xAir, building30.xAirAmb);
+  connect(ambience.xAir, building33.xAirAmb);
+  connect(ambience.xAir, building34.xAirAmb);
+  connect(ambience.xAir, building35.xAirAmb);
+  connect(ambience.xAir, building39.xAirAmb);
+  connect(ambience.xAir, building40.xAirAmb);
+  connect(ambience.xAir, building43.xAirAmb);
+  connect(ambience.xAir, building44.xAirAmb);
+  connect(ambience.xAir, building45.xAirAmb);
+  connect(ambience.xAir, building46.xAirAmb);
+  connect(ambience.xAir, building47.xAirAmb);
+  connect(ambience.xAir, building48.xAirAmb);
+  connect(ambience.xAir, building50.xAirAmb);
+  connect(ambience.xAir, building51.xAirAmb);
+  connect(ambience.xAir, building52.xAirAmb);
+  connect(ambience.xAir, building53.xAirAmb);
+  connect(ambience.xAir, building54.xAirAmb);
+  connect(ambience.xAir, building55.xAirAmb);
+
+
+  connect(t_set_heating.y, building43.T_setHeating[1]) annotation (Line(points={{-208.4,
+          320},{-214,320},{-214,310},{-220.2,310}}, color={0,0,127}));
+  connect(t_set_cooling.y, building43.T_setCooling[1])
+    annotation (Line(points={{-208.4,308},{-220.2,308}}, color={0,0,127}));
+  connect(set_airchange.y, building43.airchange[1]) annotation (Line(points={{-208.4,
+          296},{-214,296},{-214,306},{-220.2,306}}, color={0,0,127}));
+  connect(t_set_heating6.y, building55.T_setHeating[1]) annotation (Line(points={{-254.4,
+          112},{-260,112},{-260,102},{-266.2,102}}, color={0,0,127}));
+  connect(t_set_cooling6.y, building55.T_setCooling[1])
+    annotation (Line(points={{-254.4,100},{-266.2,100}}, color={0,0,127}));
+  connect(set_airchange6.y, building55.airchange[1]) annotation (Line(points={{-254.4,
+          88},{-260,88},{-260,98},{-266.2,98}}, color={0,0,127}));
+  connect(t_set_heating7.y, building35.T_setHeating[1]) annotation (Line(points={{
+          -314.4,-8},{-320,-8},{-320,-18},{-326.2,-18}}, color={0,0,127}));
+  connect(t_set_cooling7.y, building35.T_setCooling[1])
+    annotation (Line(points={{-314.4,-20},{-326.2,-20}}, color={0,0,127}));
+  connect(set_airchange7.y, building35.airchange[1]) annotation (Line(points={{-314.4,
+          -32},{-320,-32},{-320,-22},{-326.2,-22}}, color={0,0,127}));
+  connect(t_set_heating2.y, building21.T_setHeating[1]) annotation (Line(points={{-110.4,
+          216},{-116,216},{-116,206},{-122.2,206}}, color={0,0,127}));
+  connect(t_set_cooling2.y, building21.T_setCooling[1])
+    annotation (Line(points={{-110.4,204},{-122.2,204}}, color={0,0,127}));
+  connect(set_airchange2.y, building21.airchange[1]) annotation (Line(points={{-110.4,
+          192},{-116,192},{-116,202},{-122.2,202}}, color={0,0,127}));
+  connect(t_set_heating1.y, building33.T_setHeating[1]) annotation (Line(points={{
+          -54.4,236},{-60,236},{-60,226},{-66.2,226}}, color={0,0,127}));
+  connect(t_set_cooling1.y, building33.T_setCooling[1])
+    annotation (Line(points={{-54.4,224},{-66.2,224}}, color={0,0,127}));
+  connect(set_airchange1.y, building33.airchange[1]) annotation (Line(points={{-54.4,
+          212},{-60,212},{-60,222},{-66.2,222}}, color={0,0,127}));
+  connect(t_set_heating3.y, building16.T_setHeating[1]) annotation (Line(
+        points={{-32.4,206},{-38,206},{-38,196},{-44.2,196}}, color={0,0,127}));
+  connect(t_set_cooling3.y, building16.T_setCooling[1])
+    annotation (Line(points={{-32.4,194},{-44.2,194}}, color={0,0,127}));
+  connect(set_airchange3.y, building16.airchange[1]) annotation (Line(points={{
+          -32.4,182},{-38,182},{-38,192},{-44.2,192}}, color={0,0,127}));
+  connect(t_set_heating5.y, building12.T_setHeating[1]) annotation (Line(points={{-152.4,
+          150},{-158,150},{-158,140},{-162.2,140}}, color={0,0,127}));
+  connect(t_set_cooling5.y, building12.T_setCooling[1])
+    annotation (Line(points={{-152.4,138},{-162.2,138}}, color={0,0,127}));
+  connect(set_airchange5.y, building12.airchange[1]) annotation (Line(points={{-152.4,
+          126},{-158,126},{-158,136},{-162.2,136}}, color={0,0,127}));
+  connect(t_set_heating13.y, building17.T_setHeating[1]) annotation (Line(points={{
+          -134.4,106},{-140,106},{-140,96},{-146.2,96}}, color={0,0,127}));
+  connect(t_set_cooling13.y, building17.T_setCooling[1])
+    annotation (Line(points={{-134.4,94},{-146.2,94}}, color={0,0,127}));
+  connect(set_airchange13.y, building17.airchange[1]) annotation (Line(points={{-134.4,
+          82},{-140,82},{-140,92},{-146.2,92}}, color={0,0,127}));
+  connect(t_set_heating18.y, building5.T_setHeating[1]) annotation (Line(points={
+          {-78.4,122},{-80,122},{-80,106},{-82.2,106}}, color={0,0,127}));
+  connect(t_set_cooling18.y, building5.T_setCooling[1]) annotation (Line(points={
+          {-78.4,110},{-80,110},{-80,104},{-82.2,104}}, color={0,0,127}));
+  connect(set_airchange18.y, building5.airchange[1]) annotation (Line(points={{-78.4,
+          98},{-80,98},{-80,102},{-82.2,102}}, color={0,0,127}));
+  connect(t_set_heating17.y, building8.T_setHeating[1]) annotation (Line(points={{-34.4,
+          148},{-38,148},{-38,134},{-40.2,134}}, color={0,0,127}));
+  connect(t_set_cooling17.y, building8.T_setCooling[1]) annotation (Line(points={{-34.4,
+          136},{-38,136},{-38,132},{-40.2,132}}, color={0,0,127}));
+  connect(set_airchange17.y, building8.airchange[1]) annotation (Line(points={{-34.4,
+          124},{-38,124},{-38,130},{-40.2,130}}, color={0,0,127}));
+  connect(t_set_heating12.y, building14.T_setHeating[1]) annotation (Line(points={{
+          -40.4,102},{-46,102},{-46,92},{-52.2,92}}, color={0,0,127}));
+  connect(t_set_cooling12.y, building14.T_setCooling[1])
+    annotation (Line(points={{-40.4,90},{-52.2,90}}, color={0,0,127}));
+  connect(set_airchange12.y, building14.airchange[1]) annotation (Line(points={{-40.4,
+          78},{-46,78},{-46,88},{-52.2,88}}, color={0,0,127}));
+  connect(t_set_heating4.y, building11.T_setHeating[1]) annotation (Line(points={{
+          7.6,156},{2,156},{2,146},{-4.2,146}}, color={0,0,127}));
+  connect(t_set_cooling4.y, building11.T_setCooling[1])
+    annotation (Line(points={{7.6,144},{-4.2,144}}, color={0,0,127}));
+  connect(set_airchange4.y, building11.airchange[1]) annotation (Line(points={{7.6,
+          132},{2,132},{2,142},{-4.2,142}}, color={0,0,127}));
+  connect(t_set_heating11.y, building10.T_setHeating[1]) annotation (Line(points={
+          {15.6,86},{10,86},{10,76},{3.8,76}}, color={0,0,127}));
+  connect(t_set_cooling11.y, building10.T_setCooling[1])
+    annotation (Line(points={{15.6,74},{3.8,74}}, color={0,0,127}));
+  connect(set_airchange11.y, building10.airchange[1]) annotation (Line(points={{15.6,
+          62},{10,62},{10,72},{3.8,72}}, color={0,0,127}));
+  connect(t_set_heating8.y, building27.T_setHeating[1]) annotation (Line(points={{77.6,
+          86},{72,86},{72,76},{65.8,76}}, color={0,0,127}));
+  connect(t_set_cooling8.y, building27.T_setCooling[1])
+    annotation (Line(points={{77.6,74},{65.8,74}}, color={0,0,127}));
+  connect(set_airchange8.y, building27.airchange[1]) annotation (Line(points={{77.6,
+          62},{72,62},{72,72},{65.8,72}}, color={0,0,127}));
+  connect(t_set_heating9.y, building47.T_setHeating[1]) annotation (Line(points={{
+          109.6,56},{104,56},{104,46},{97.8,46}}, color={0,0,127}));
+  connect(t_set_cooling9.y, building47.T_setCooling[1])
+    annotation (Line(points={{109.6,44},{97.8,44}}, color={0,0,127}));
+  connect(set_airchange9.y, building47.airchange[1]) annotation (Line(points={{109.6,
+          32},{104,32},{104,42},{97.8,42}}, color={0,0,127}));
+  connect(t_set_heating10.y, building34.T_setHeating[1]) annotation (Line(points={{
+          49.6,48},{44,48},{44,38},{37.8,38}}, color={0,0,127}));
+  connect(t_set_cooling10.y, building34.T_setCooling[1])
+    annotation (Line(points={{49.6,36},{37.8,36}}, color={0,0,127}));
+  connect(set_airchange10.y, building34.airchange[1]) annotation (Line(points={{49.6,
+          24},{44,24},{44,34},{37.8,34}}, color={0,0,127}));
+  connect(t_set_heating19.y, building25.T_setHeating[1]) annotation (Line(points={{
+          -30.4,62},{-36,62},{-36,52},{-42.2,52}}, color={0,0,127}));
+  connect(t_set_cooling19.y, building25.T_setCooling[1])
+    annotation (Line(points={{-30.4,50},{-42.2,50}}, color={0,0,127}));
+  connect(set_airchange19.y, building25.airchange[1]) annotation (Line(points={{-30.4,
+          38},{-36,38},{-36,48},{-42.2,48}}, color={0,0,127}));
+  connect(t_set_heating20.y, building40.T_setHeating[1]) annotation (Line(points={{-98.4,
+          44},{-104,44},{-104,34},{-110.2,34}}, color={0,0,127}));
+  connect(t_set_cooling20.y, building40.T_setCooling[1])
+    annotation (Line(points={{-98.4,32},{-110.2,32}}, color={0,0,127}));
+  connect(set_airchange20.y, building40.airchange[1]) annotation (Line(points={{-98.4,
+          20},{-104,20},{-104,30},{-110.2,30}}, color={0,0,127}));
+  connect(t_set_heating21.y, building1.T_setHeating[1]) annotation (Line(points={{-150.4,
+          58},{-156,58},{-156,48},{-162.2,48}}, color={0,0,127}));
+  connect(t_set_cooling21.y, building1.T_setCooling[1])
+    annotation (Line(points={{-150.4,46},{-162.2,46}}, color={0,0,127}));
+  connect(set_airchange21.y, building1.airchange[1]) annotation (Line(points={{-150.4,
+          34},{-156,34},{-156,44},{-162.2,44}}, color={0,0,127}));
+  connect(t_set_heating14.y, building39.T_setHeating[1]) annotation (Line(points={
+          {319.6,-52},{314,-52},{314,-62},{307.8,-62}}, color={0,0,127}));
+  connect(t_set_cooling14.y, building39.T_setCooling[1])
+    annotation (Line(points={{319.6,-64},{307.8,-64}}, color={0,0,127}));
+  connect(set_airchange14.y, building39.airchange[1]) annotation (Line(points={{319.6,
+          -76},{314,-76},{314,-66},{307.8,-66}}, color={0,0,127}));
+  connect(t_set_heating16.y, building23.T_setHeating[1]) annotation (Line(points={{311.6,
+          -124},{306,-124},{306,-134},{299.8,-134}}, color={0,0,127}));
+  connect(t_set_cooling16.y, building23.T_setCooling[1])
+    annotation (Line(points={{311.6,-136},{299.8,-136}}, color={0,0,127}));
+  connect(set_airchange16.y, building23.airchange[1]) annotation (Line(points={{311.6,
+          -148},{306,-148},{306,-138},{299.8,-138}}, color={0,0,127}));
+  connect(t_set_heating15.y, building51.T_setHeating[1]) annotation (
+      Line(points={{267.6,-112},{262,-112},{262,-122},{255.8,-122}}, color={0,0,
+          127}));
+  connect(t_set_cooling15.y, building51.T_setCooling[1])
+    annotation (Line(points={{267.6,-124},{255.8,-124}}, color={0,0,127}));
+  connect(set_airchange15.y, building51.airchange[1]) annotation (Line(
+        points={{267.6,-136},{262,-136},{262,-126},{255.8,-126}}, color={0,0,127}));
+  connect(t_set_heating30.y, building7.T_setHeating[1]) annotation (Line(points={{135.6,
+          -58},{128,-58},{128,-68},{123.8,-68}}, color={0,0,127}));
+  connect(t_set_cooling30.y, building7.T_setCooling[1])
+    annotation (Line(points={{135.6,-70},{123.8,-70}}, color={0,0,127}));
+  connect(set_airchange30.y, building7.airchange[1]) annotation (Line(points={{135.6,
+          -82},{128,-82},{128,-72},{123.8,-72}}, color={0,0,127}));
+  connect(t_set_heating31.y, building29.T_setHeating[1]) annotation (Line(points={{
+          129.6,-106},{124,-106},{124,-116},{117.8,-116}}, color={0,0,127}));
+  connect(t_set_cooling31.y, building29.T_setCooling[1])
+    annotation (Line(points={{129.6,-118},{117.8,-118}}, color={0,0,127}));
+  connect(set_airchange31.y, building29.airchange[1]) annotation (Line(points={{129.6,
+          -130},{124,-130},{124,-120},{117.8,-120}}, color={0,0,127}));
+  connect(t_set_heating32.y, building52.T_setHeating[1]) annotation (Line(
+        points={{159.6,-132},{154,-132},{154,-142},{147.8,-142}}, color={0,0,127}));
+  connect(t_set_cooling32.y, building52.T_setCooling[1])
+    annotation (Line(points={{159.6,-144},{147.8,-144}}, color={0,0,127}));
+  connect(set_airchange32.y, building52.airchange[1]) annotation (Line(
+        points={{159.6,-156},{154,-156},{154,-146},{147.8,-146}}, color={0,0,127}));
+  connect(t_set_heating33.y, building54.T_setHeating[1]) annotation (Line(
+        points={{113.6,-146},{108,-146},{108,-156},{101.8,-156}}, color={0,0,127}));
+  connect(t_set_cooling33.y, building54.T_setCooling[1])
+    annotation (Line(points={{113.6,-158},{101.8,-158}}, color={0,0,127}));
+  connect(set_airchange33.y, building54.airchange[1]) annotation (Line(points=
+         {{113.6,-170},{108,-170},{108,-160},{101.8,-160}}, color={0,0,127}));
+  connect(t_set_heating34.y, building53.T_setHeating[1]) annotation (Line(
+        points={{89.6,-182},{84,-182},{84,-192},{77.8,-192}}, color={0,0,127}));
+  connect(t_set_cooling34.y, building53.T_setCooling[1])
+    annotation (Line(points={{89.6,-194},{77.8,-194}}, color={0,0,127}));
+  connect(set_airchange34.y, building53.airchange[1]) annotation (Line(points={{
+          89.6,-206},{84,-206},{84,-196},{77.8,-196}}, color={0,0,127}));
+  connect(t_set_heating35.y, building48.T_setHeating[1]) annotation (Line(points={
+          {189.6,-202},{184,-202},{184,-212},{177.8,-212}}, color={0,0,127}));
+  connect(t_set_cooling35.y, building48.T_setCooling[1])
+    annotation (Line(points={{189.6,-214},{177.8,-214}}, color={0,0,127}));
+  connect(set_airchange35.y, building48.airchange[1]) annotation (Line(points={{189.6,
+          -226},{184,-226},{184,-216},{177.8,-216}}, color={0,0,127}));
+  connect(t_set_heating37.y, building44.T_setHeating[1]) annotation (Line(points={{
+          85.6,-286},{80,-286},{80,-296},{73.8,-296}}, color={0,0,127}));
+  connect(t_set_cooling37.y, building44.T_setCooling[1])
+    annotation (Line(points={{85.6,-298},{73.8,-298}}, color={0,0,127}));
+  connect(set_airchange37.y, building44.airchange[1]) annotation (Line(points={{85.6,
+          -310},{80,-310},{80,-300},{73.8,-300}}, color={0,0,127}));
+  connect(t_set_heating36.y, building45.T_setHeating[1]) annotation (Line(points={{
+          19.6,-282},{14,-282},{14,-292},{7.8,-292}}, color={0,0,127}));
+  connect(t_set_cooling36.y, building45.T_setCooling[1])
+    annotation (Line(points={{19.6,-294},{7.8,-294}}, color={0,0,127}));
+  connect(set_airchange36.y, building45.airchange[1]) annotation (Line(points={{19.6,
+          -306},{14,-306},{14,-296},{7.8,-296}}, color={0,0,127}));
+  connect(t_set_heating23.y, building13.T_setHeating[1]) annotation (Line(points={{17.6,
+          -76},{12,-76},{12,-86},{5.8,-86}}, color={0,0,127}));
+  connect(t_set_cooling23.y, building13.T_setCooling[1])
+    annotation (Line(points={{17.6,-88},{5.8,-88}}, color={0,0,127}));
+  connect(set_airchange23.y, building13.airchange[1]) annotation (Line(points={{17.6,
+          -100},{12,-100},{12,-90},{5.8,-90}}, color={0,0,127}));
+  connect(t_set_heating22.y, building9.T_setHeating[1]) annotation (Line(points={{
+          -106.4,-68},{-112,-68},{-112,-78},{-118.2,-78}}, color={0,0,127}));
+  connect(t_set_cooling22.y, building9.T_setCooling[1])
+    annotation (Line(points={{-106.4,-80},{-118.2,-80}}, color={0,0,127}));
+  connect(set_airchange22.y, building9.airchange[1]) annotation (Line(points={{-106.4,
+          -92},{-112,-92},{-112,-82},{-118.2,-82}}, color={0,0,127}));
+  connect(t_set_heating24.y, building6.T_setHeating[1]) annotation (Line(points={{-168.4,
+          -94},{-174,-94},{-174,-104},{-184.2,-104}},        color={0,0,127}));
+  connect(t_set_cooling24.y, building6.T_setCooling[1])
+    annotation (Line(points={{-168.4,-106},{-184.2,-106}}, color={0,0,127}));
+  connect(set_airchange24.y, building6.airchange[1]) annotation (Line(points={{-168.4,
+          -118},{-174,-118},{-174,-108},{-184.2,-108}}, color={0,0,127}));
+  connect(t_set_heating26.y, building3.T_setHeating[1]) annotation (Line(points={{-110.4,
+          -114},{-116,-114},{-116,-124},{-122.2,-124}}, color={0,0,127}));
+  connect(t_set_cooling26.y, building3.T_setCooling[1])
+    annotation (Line(points={{-110.4,-126},{-122.2,-126}}, color={0,0,127}));
+  connect(set_airchange26.y, building3.airchange[1]) annotation (Line(points={{-110.4,
+          -138},{-116,-138},{-116,-128},{-122.2,-128}}, color={0,0,127}));
+  connect(t_set_heating27.y, building50.T_setHeating[1]) annotation (Line(
+        points={{-84.4,-144},{-90,-144},{-90,-152},{-96.2,-152}}, color={0,0,127}));
+  connect(t_set_cooling27.y, building50.T_setCooling[1]) annotation (Line(
+        points={{-84.4,-156},{-90,-156},{-90,-154},{-96.2,-154}}, color={0,0,127}));
+  connect(set_airchange27.y, building50.airchange[1]) annotation (Line(
+        points={{-84.4,-168},{-90,-168},{-90,-156},{-96.2,-156}}, color={0,0,127}));
+  connect(t_set_heating28.y, building2.T_setHeating[1]) annotation (Line(points={{
+          -126.4,-152},{-132,-152},{-132,-144},{-136.2,-144}}, color={0,0,127}));
+  connect(t_set_cooling28.y, building2.T_setCooling[1]) annotation (Line(points={{
+          -126.4,-164},{-132,-164},{-132,-146},{-136.2,-146}}, color={0,0,127}));
+  connect(set_airchange28.y, building2.airchange[1]) annotation (Line(points={{-126.4,
+          -176},{-132,-176},{-132,-148},{-136.2,-148}}, color={0,0,127}));
+  connect(t_set_heating25.y, building46.T_setHeating[1]) annotation (Line(
+        points={{-164.4,-132},{-166.2,-132},{-166.2,-146}}, color={0,0,127}));
+  connect(t_set_cooling25.y, building46.T_setCooling[1]) annotation (Line(
+        points={{-164.4,-144},{-166.2,-144},{-166.2,-148}}, color={0,0,127}));
+  connect(set_airchange25.y, building46.airchange[1]) annotation (Line(points={{
+          -164.4,-156},{-166.2,-156},{-166.2,-150}}, color={0,0,127}));
+  connect(t_set_heating29.y, building30.T_setHeating[1]) annotation (Line(points={
+          {-88.4,-188},{-94,-188},{-94,-198},{-100.2,-198}}, color={0,0,127}));
+  connect(t_set_cooling29.y, building30.T_setCooling[1])
+    annotation (Line(points={{-88.4,-200},{-100.2,-200}}, color={0,0,127}));
+  connect(set_airchange29.y, building30.airchange[1]) annotation (Line(points={{-88.4,
+          -212},{-94,-212},{-94,-202},{-100.2,-202}}, color={0,0,127}));
+  connect(groundBuilding45.port, building45.toSolidHeatPorts[1])
+    annotation (Line(points={{-2,-316},{-2,-312},{-6,-312},{-6,-309}},
+                                                     color={191,0,0}));
+  connect(groundBuilding44.port, building44.toSolidHeatPorts[1])
+    annotation (Line(points={{64,-320},{64,-316},{60,-316},{60,-313}},
+                                                     color={191,0,0}));
+  connect(groundBuilding39.port, building39.toSolidHeatPorts[1]) annotation (
+      Line(points={{298,-86},{298,-79},{294,-79}},   color={191,0,0}));
+  connect(groundBuilding23.port, building23.toSolidHeatPorts[1])
+    annotation (Line(points={{290,-158},{290,-154},{286,-154},{286,-151}},
+                                                       color={191,0,0}));
+  connect(groundBuilding51.port, building51.toSolidHeatPorts[1])
+    annotation (Line(points={{246,-146},{246,-142},{242,-142},{242,-139}},
+                                                       color={191,0,0}));
+  connect(groundBuilding53.port, building53.toSolidHeatPorts[1])
+    annotation (Line(points={{68,-216},{68,-212},{64,-212},{64,-209}},
+                                                     color={191,0,0}));
+  connect(groundBuilding54.port, building54.toSolidHeatPorts[1]) annotation (
+     Line(points={{76,-180},{80,-180},{80,-173},{88,-173}},     color={191,0,0}));
+  connect(groundBuilding52.port, building52.toSolidHeatPorts[1])
+    annotation (Line(points={{138,-166},{138,-162},{134,-162},{134,-159}},
+                                                       color={191,0,0}));
+  connect(groundBuilding29.port, building29.toSolidHeatPorts[1])
+    annotation (Line(points={{108,-140},{108,-136},{104,-136},{104,-133}},
+                                                       color={191,0,0}));
+  connect(groundBuilding7.port, building7.toSolidHeatPorts[1])
+    annotation (Line(points={{114,-92},{114,-88},{110,-88},{110,-85}},
+                                                     color={191,0,0}));
+  connect(groundBuilding13.port, building13.toSolidHeatPorts[1])
+    annotation (Line(points={{-4,-110},{-4,-106},{-8,-106},{-8,-103}},
+                                                     color={191,0,0}));
+  connect(groundBuilding9.port, building9.toSolidHeatPorts[1])
+    annotation (Line(points={{-128,-102},{-128,-98},{-132,-98},{-132,-95}},
+                                                       color={191,0,0}));
+  connect(groundBuilding6.port, building6.toSolidHeatPorts[1])
+    annotation (Line(points={{-194,-128},{-194,-124},{-198,-124},{-198,-121}},
+                                                         color={191,0,0}));
+  connect(groundBuilding46.port, building46.toSolidHeatPorts[1])
+    annotation (Line(points={{-176,-170},{-176,-166},{-180,-166},{-180,-163}},
+                                                         color={191,0,0}));
+  connect(groundBuilding2.port, building2.toSolidHeatPorts[1])
+    annotation (Line(points={{-146,-168},{-146,-164},{-150,-164},{-150,-161}},
+                                                         color={191,0,0}));
+  connect(groundBuilding3.port, building3.toSolidHeatPorts[1]) annotation (Line(
+        points={{-134,-170},{-136,-170},{-136,-141}},     color={191,0,0}));
+  connect(groundBuilding50.port, building50.toSolidHeatPorts[1])
+    annotation (Line(points={{-106,-176},{-106,-172},{-110,-172},{-110,-169}},
+                                                         color={191,0,0}));
+  connect(groundBuilding30.port, building30.toSolidHeatPorts[1])
+    annotation (Line(points={{-110,-222},{-110,-218},{-114,-218},{-114,-215}},
+                                                         color={191,0,0}));
+  connect(groundBuilding35.port, building35.toSolidHeatPorts[1])
+    annotation (Line(points={{-336,-42},{-336,-38},{-340,-38},{-340,-35}},
+                                                       color={191,0,0}));
+  connect(groundBuilding55.port, building55.toSolidHeatPorts[1])
+    annotation (Line(points={{-276,78},{-276,82},{-280,82},{-280,85}},
+                                                     color={191,0,0}));
+  connect(groundBuilding43.port, building43.toSolidHeatPorts[1])
+    annotation (Line(points={{-230,286},{-230,290},{-234,290},{-234,293}},
+                                                       color={191,0,0}));
+  connect(groundBuilding47.port, building47.toSolidHeatPorts[1])
+    annotation (Line(points={{88,22},{88,26},{84,26},{84,29}},
+                                                 color={191,0,0}));
+  connect(groundBuilding34.port, building34.toSolidHeatPorts[1])
+    annotation (Line(points={{28,14},{28,18},{24,18},{24,21}},
+                                                 color={191,0,0}));
+  connect(groundBuilding27.port, building27.toSolidHeatPorts[1]) annotation (
+      Line(points={{42,52},{46,52},{46,59},{52,59}},     color={191,0,0}));
+  connect(groundBuilding10.port, building10.toSolidHeatPorts[1])
+    annotation (Line(points={{-6,52},{-6,56},{-10,56},{-10,59}},
+                                                   color={191,0,0}));
+  connect(groundBuilding25.port, building25.toSolidHeatPorts[1])
+    annotation (Line(points={{-52,28},{-52,32},{-56,32},{-56,35}},
+                                                   color={191,0,0}));
+  connect(groundBuilding14.port, building14.toSolidHeatPorts[1])
+    annotation (Line(points={{-62,68},{-62,72},{-66,72},{-66,75}},
+                                                   color={191,0,0}));
+  connect(groundBuilding5.port, building5.toSolidHeatPorts[1])
+    annotation (Line(points={{-92,82},{-92,86},{-96,86},{-96,89}},
+                                                   color={191,0,0}));
+  connect(groundBuilding40.port, building40.toSolidHeatPorts[1])
+    annotation (Line(points={{-120,10},{-120,14},{-124,14},{-124,17}},
+                                                     color={191,0,0}));
+  connect(groundBuilding1.port, building1.toSolidHeatPorts[1])
+    annotation (Line(points={{-172,24},{-172,28},{-176,28},{-176,31}},
+                                                     color={191,0,0}));
+  connect(groundBuilding17.port, building17.toSolidHeatPorts[1])
+    annotation (Line(points={{-156,72},{-156,76},{-160,76},{-160,79}},
+                                                     color={191,0,0}));
+  connect(groundBuilding12.port, building12.toSolidHeatPorts[1])
+    annotation (Line(points={{-172,116},{-172,120},{-176,120},{-176,123}},
+                                                       color={191,0,0}));
+  connect(building8.toSolidHeatPorts[1], groundBuilding8.port)
+    annotation (Line(points={{-54,117},{-54,114},{-54,110},{-50,110}},
+                                                     color={191,0,0}));
+  connect(groundBuilding11.port, building11.toSolidHeatPorts[1])
+    annotation (Line(points={{-14,122},{-14,126},{-18,126},{-18,129}},
+                                                     color={191,0,0}));
+  connect(groundBuilding16.port, building16.toSolidHeatPorts[1])
+    annotation (Line(points={{-54,172},{-54,176},{-58,176},{-58,179}},
+                                                     color={191,0,0}));
+  connect(groundBuilding33.port, building33.toSolidHeatPorts[1])
+    annotation (Line(points={{-76,202},{-76,206},{-80,206},{-80,209}},
+                                                     color={191,0,0}));
+  connect(groundBuilding21.port, building21.toSolidHeatPorts[1])
+    annotation (Line(points={{-132,182},{-132,186},{-136,186},{-136,189}},
+                                                       color={191,0,0}));
+
+  annotation (__Dymola_Commands(file="modelica://BuildingSystems/Resources/Scripts/Dymola/Applications/DistrictSimulation/HCBC.mos" "Simulate and plot"),
+    Diagram(coordinateSystem(extent={{-400,-400},{400,400}},preserveAspectRatio=false),
+    graphics={Bitmap(extent={{-398,-402},{396,400}},
+    fileName="modelica://BuildingSystems/Resources/Images/Applications/DistrictSimulation/HCBCBackground.png")}),
+    experiment(StopTime=864000),
+    __Dymola_experimentSetupOutput(events=false),
+Documentation(info="<html>
+<p>
+Example that simulates heating and cooling demand of the university campus in Berlin-Charlottenburg (Germany).
+</p>
+</html>",
+revisions="<html>
+<ul>
+<li>
+April 27, 2017, by Alexander Inderfurth:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end HCBC_Comfort;

--- a/BuildingSystems/Applications/DistrictSimulation/HCBC_Comfort.mo
+++ b/BuildingSystems/Applications/DistrictSimulation/HCBC_Comfort.mo
@@ -10,8 +10,9 @@ model HCBC_Comfort
     nIdealLoads = 1,
     nSurfacesSolid=1,
     surfacesToAmbience(nSurfaces=9),
-    nZones=1);
-  BuildingSystems.Buildings.Zones.ZoneTemplateAirvolumeMixed zone(
+    nZones=1,
+    useAirPaths = false);
+  BuildingSystems.Buildings.Zones.ZoneTemplateAirvolumeMixedCO2 zone(
     calcThermalComfort = true,
     nConstructions=10,
     V=parameterMap.VZon,
@@ -163,7 +164,7 @@ model HCBC_Comfort
       lambda=parameterMap.lambdaOut,
       c=parameterMap.cOut,
       rho=parameterMap.rhoOut)})
-    annotation (Placement(transformation(extent={{140,94},{160,114}})));
+    annotation (Placement(transformation(extent={{142,90},{162,110}})));
 
   BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction bottomConstruction(
     nLayers=1,
@@ -178,6 +179,15 @@ model HCBC_Comfort
   replaceable parameter ParameterMap parameterMap
     annotation (choicesAllMatching=true, Placement(transformation(extent={{-118,70},
               {-98,90}})));
+  Modelica.Blocks.Interfaces.RealInput C_in[nZones]
+      "CO2 connexion port to the building zones" annotation (Placement(
+          transformation(
+          extent={{10,-10},{-10,10}},
+          rotation=0,
+          origin={98,98}),  iconTransformation(
+          extent={{10,-10},{-10,10}},
+          rotation=0,
+          origin={98,98})));
   equation
 
   connect(surfacesToAmbience.toConstructionPorts[1], wall1.toSurfacePort_2)
@@ -268,6 +278,8 @@ model HCBC_Comfort
       annotation (Line(points={{0,120},{0,-10.7},{4.9,-10.7}},
                                                              color={127,0,0}));
 
+    connect(zone.C_in, C_in[1]) annotation (Line(points={{15,-7},{14,-7},{14,22},
+            {72,22},{72,98},{98,98}},            color={0,0,127}));
   end Building;
 
   record ParameterMap
@@ -1413,14 +1425,14 @@ model HCBC_Comfort
   Building building2(nZones=1, parameterMap = parameterMap2, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{-156,-162},{-136,-142}})));
   Building building3(nZones=1, parameterMap = parameterMap3, nIdealLoads = 1)
-    annotation (Placement(transformation(extent={{-142,-142},{-122,-122}})));
+    annotation (Placement(transformation(extent={{-142,-132},{-122,-112}})));
   Building building5(nZones=1, parameterMap = parameterMap5, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{-102,88},{-82,108}})));
   Building building6(nZones=1, parameterMap = parameterMap6, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{-204,-122},{-184,-102}})));
   Building building7(nZones=1, parameterMap = parameterMap7, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{104,-86},{124,-66}})));
-  Building building8(nZones=1, parameterMap = parameterMap8, nIdealLoads = 1)
+  Building building8(          parameterMap = parameterMap8, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{-60,116},{-40,136}})));
   Building building9(nZones=1, parameterMap = parameterMap9, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{-138,-96},{-118,-76}})));
@@ -1467,8 +1479,8 @@ model HCBC_Comfort
   Building building45(nZones=1, parameterMap = parameterMap45, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{-12,-310},{8,-290}})));
   Building building46(nZones=1, parameterMap = parameterMap46, nIdealLoads = 1)
-    annotation (Placement(transformation(extent={{-186,-164},{-166,-144}})));
-  Building building47(nZones=1, parameterMap = parameterMap47, nIdealLoads = 1)
+    annotation (Placement(transformation(extent={{-200,-164},{-180,-144}})));
+  Building building47(          parameterMap = parameterMap47, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{78,28},{98,48}})));
   Building building48(nZones=1, parameterMap = parameterMap48, nIdealLoads = 1)
     annotation (Placement(transformation(extent={{158,-230},{178,-210}})));
@@ -1702,13 +1714,13 @@ model HCBC_Comfort
     annotation (Placement(transformation(extent={{26,-104},{18,-96}})));
   Modelica.Blocks.Sources.Constant t_set_cooling24(
     k=building6.parameterMap.TSetCoo)
-    annotation (Placement(transformation(extent={{-160,-110},{-168,-102}})));
+    annotation (Placement(transformation(extent={{-168,-110},{-176,-102}})));
   Modelica.Blocks.Sources.Constant t_set_heating24(
     k=building6.parameterMap.TSetHea)
-    annotation (Placement(transformation(extent={{-160,-98},{-168,-90}})));
+    annotation (Placement(transformation(extent={{-168,-98},{-176,-90}})));
   Modelica.Blocks.Sources.Constant set_airchange24(
     k=building6.parameterMap.airchange)
-    annotation (Placement(transformation(extent={{-160,-122},{-168,-114}})));
+    annotation (Placement(transformation(extent={{-168,-122},{-176,-114}})));
   Modelica.Blocks.Sources.Constant t_set_cooling25(
     k=building46.parameterMap.TSetCoo)
     annotation (Placement(transformation(extent={{-156,-148},{-164,-140}})));
@@ -1747,13 +1759,13 @@ model HCBC_Comfort
     annotation (Placement(transformation(extent={{-118,-180},{-126,-172}})));
   Modelica.Blocks.Sources.Constant t_set_cooling29(
     k=building30.parameterMap.TSetCoo)
-    annotation (Placement(transformation(extent={{-80,-204},{-88,-196}})));
+    annotation (Placement(transformation(extent={{-80,-210},{-88,-202}})));
   Modelica.Blocks.Sources.Constant t_set_heating29(
     k=building30.parameterMap.TSetHea)
-    annotation (Placement(transformation(extent={{-80,-192},{-88,-184}})));
+    annotation (Placement(transformation(extent={{-80,-198},{-88,-190}})));
   Modelica.Blocks.Sources.Constant set_airchange29(
     k=building30.parameterMap.airchange)
-    annotation (Placement(transformation(extent={{-80,-216},{-88,-208}})));
+    annotation (Placement(transformation(extent={{-80,-222},{-88,-214}})));
   Modelica.Blocks.Sources.Constant t_set_cooling30(
     k=building7.parameterMap.TSetCoo)
     annotation (Placement(transformation(extent={{144,-74},{136,-66}})));
@@ -1853,17 +1865,17 @@ model HCBC_Comfort
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding9(T=283.15)
     annotation (Placement(transformation(extent={{-136,-106},{-128,-98}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding6(T=283.15)
-    annotation (Placement(transformation(extent={{-202,-132},{-194,-124}})));
+    annotation (Placement(transformation(extent={{-206,-134},{-198,-126}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding2(T=283.15)
     annotation (Placement(transformation(extent={{-154,-172},{-146,-164}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding46(T=283.15)
-    annotation (Placement(transformation(extent={{-184,-174},{-176,-166}})));
+    annotation (Placement(transformation(extent={{-186,-176},{-178,-168}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding50(T=283.15)
     annotation (Placement(transformation(extent={{-114,-180},{-106,-172}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding30(T=283.15)
     annotation (Placement(transformation(extent={{-118,-226},{-110,-218}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding3(T=283.15)
-    annotation (Placement(transformation(extent={{-142,-174},{-134,-166}})));
+    annotation (Placement(transformation(extent={{-152,-136},{-144,-128}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding35(T=283.15)
     annotation (Placement(transformation(extent={{-344,-46},{-336,-38}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding55(T=283.15)
@@ -1902,6 +1914,83 @@ model HCBC_Comfort
     annotation (Placement(transformation(extent={{34,48},{42,56}})));
   Modelica.Thermal.HeatTransfer.Sources.FixedTemperature groundBuilding47(T=283.15)
     annotation (Placement(transformation(extent={{80,18},{88,26}})));
+
+  Modelica.Blocks.Sources.Constant CO2_in1(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-142,68},{-150,76}})));
+  Modelica.Blocks.Sources.Constant CO2_in2(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-118,-144},{-126,-136}})));
+  Modelica.Blocks.Sources.Constant CO2_in3(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-102,-108},{-110,-100}})));
+  Modelica.Blocks.Sources.Constant CO2_in5(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-70,134},{-78,142}})));
+  Modelica.Blocks.Sources.Constant CO2_in6(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-168,-86},{-176,-78}})));
+  Modelica.Blocks.Sources.Constant CO2_in7(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{144,-46},{136,-38}})));
+  Modelica.Blocks.Sources.Constant CO2_in11(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{16,170},{8,178}})));
+  Modelica.Blocks.Sources.Constant CO2_in9(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-98,-58},{-106,-50}})));
+  Modelica.Blocks.Sources.Constant CO2_in10(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{24,96},{16,104}})));
+  Modelica.Blocks.Sources.Constant CO2_in46(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-156,-126},{-164,-118}})));
+  Modelica.Blocks.Sources.Constant CO2_in12(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-144,162},{-152,170}})));
+  Modelica.Blocks.Sources.Constant CO2_in13(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{26,-66},{18,-58}})));
+  Modelica.Blocks.Sources.Constant CO2_in14(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-32,108},{-40,116}})));
+  Modelica.Blocks.Sources.Constant CO2_in16(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-24,218},{-32,226}})));
+  Modelica.Blocks.Sources.Constant CO2_in17(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-126,118},{-134,126}})));
+  Modelica.Blocks.Sources.Constant CO2_in21(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-102,224},{-110,232}})));
+  Modelica.Blocks.Sources.Constant CO2_in23(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{320,-114},{312,-106}})));
+  Modelica.Blocks.Sources.Constant CO2_in25(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-22,72},{-30,80}})));
+  Modelica.Blocks.Sources.Constant CO2_in27(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{86,94},{78,102}})));
+  Modelica.Blocks.Sources.Constant CO2_in29(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{138,-98},{130,-90}})));
+  Modelica.Blocks.Sources.Constant CO2_in30(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-80,-186},{-88,-178}})));
+  Modelica.Blocks.Sources.Constant CO2_in33(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-46,246},{-54,254}})));
+  Modelica.Blocks.Sources.Constant CO2_in34(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{58,4},{50,12}})));
+  Modelica.Blocks.Sources.Constant CO2_in35(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-306,6},{-314,14}})));
+  Modelica.Blocks.Sources.Constant CO2_in39(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{328,-40},{320,-32}})));
+  Modelica.Blocks.Sources.Constant CO2_in40(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-90,54},{-98,62}})));
+  Modelica.Blocks.Sources.Constant CO2_in43(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-200,332},{-208,340}})));
+  Modelica.Blocks.Sources.Constant CO2_in44(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{94,-278},{86,-270}})));
+  Modelica.Blocks.Sources.Constant CO2_in45(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{28,-272},{20,-264}})));
+  Modelica.Blocks.Sources.Constant CO2_in48(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{198,-190},{190,-182}})));
+  Modelica.Blocks.Sources.Constant CO2_in47(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{118,66},{110,74}})));
+  Modelica.Blocks.Sources.Constant CO2_in50(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-76,-132},{-84,-124}})));
+  Modelica.Blocks.Sources.Constant CO2_in51(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{276,-102},{268,-94}})));
+  Modelica.Blocks.Sources.Constant CO2_in52(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{168,-120},{160,-112}})));
+  Modelica.Blocks.Sources.Constant CO2_in53(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{96,-224},{88,-216}})));
+  Modelica.Blocks.Sources.Constant CO2_in54(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{122,-186},{114,-178}})));
+  Modelica.Blocks.Sources.Constant CO2_in55(k=3500) "CO2 source"
+    annotation (Placement(transformation(extent={{-246,122},{-254,130}})));
+  Modelica.Blocks.Sources.Constant CO2_in8(k=3500)  "CO2 source"
+    annotation (Placement(transformation(extent={{-26,158},{-34,166}})));
 equation
 
   der(Q_district) = Q_flowHea;
@@ -2265,18 +2354,19 @@ equation
     annotation (Line(points={{-106.4,-80},{-118.2,-80}}, color={0,0,127}));
   connect(set_airchange22.y, building9.airchange[1]) annotation (Line(points={{-106.4,
           -92},{-112,-92},{-112,-82},{-118.2,-82}}, color={0,0,127}));
-  connect(t_set_heating24.y, building6.T_setHeating[1]) annotation (Line(points={{-168.4,
-          -94},{-174,-94},{-174,-104},{-184.2,-104}},        color={0,0,127}));
+  connect(t_set_heating24.y, building6.T_setHeating[1]) annotation (Line(points={{-176.4,
+          -94},{-176.4,-100},{-184.2,-100},{-184.2,-104}},   color={0,0,127}));
   connect(t_set_cooling24.y, building6.T_setCooling[1])
-    annotation (Line(points={{-168.4,-106},{-184.2,-106}}, color={0,0,127}));
-  connect(set_airchange24.y, building6.airchange[1]) annotation (Line(points={{-168.4,
-          -118},{-174,-118},{-174,-108},{-184.2,-108}}, color={0,0,127}));
+    annotation (Line(points={{-176.4,-106},{-184.2,-106}}, color={0,0,127}));
+  connect(set_airchange24.y, building6.airchange[1]) annotation (Line(points={{-176.4,
+          -118},{-184.2,-118},{-184.2,-108}},           color={0,0,127}));
   connect(t_set_heating26.y, building3.T_setHeating[1]) annotation (Line(points={{-110.4,
-          -114},{-116,-114},{-116,-124},{-122.2,-124}}, color={0,0,127}));
+          -114},{-122.2,-114}},                         color={0,0,127}));
   connect(t_set_cooling26.y, building3.T_setCooling[1])
-    annotation (Line(points={{-110.4,-126},{-122.2,-126}}, color={0,0,127}));
+    annotation (Line(points={{-110.4,-126},{-120,-126},{-120,-116},{-122.2,-116}},
+                                                           color={0,0,127}));
   connect(set_airchange26.y, building3.airchange[1]) annotation (Line(points={{-110.4,
-          -138},{-116,-138},{-116,-128},{-122.2,-128}}, color={0,0,127}));
+          -138},{-122.2,-138},{-122.2,-118}},           color={0,0,127}));
   connect(t_set_heating27.y, building50.T_setHeating[1]) annotation (Line(
         points={{-84.4,-144},{-90,-144},{-90,-152},{-96.2,-152}}, color={0,0,127}));
   connect(t_set_cooling27.y, building50.T_setCooling[1]) annotation (Line(
@@ -2290,17 +2380,19 @@ equation
   connect(set_airchange28.y, building2.airchange[1]) annotation (Line(points={{-126.4,
           -176},{-132,-176},{-132,-148},{-136.2,-148}}, color={0,0,127}));
   connect(t_set_heating25.y, building46.T_setHeating[1]) annotation (Line(
-        points={{-164.4,-132},{-166.2,-132},{-166.2,-146}}, color={0,0,127}));
+        points={{-164.4,-132},{-172,-132},{-172,-146},{-180.2,-146}},
+                                                            color={0,0,127}));
   connect(t_set_cooling25.y, building46.T_setCooling[1]) annotation (Line(
-        points={{-164.4,-144},{-166.2,-144},{-166.2,-148}}, color={0,0,127}));
-  connect(set_airchange25.y, building46.airchange[1]) annotation (Line(points={{
-          -164.4,-156},{-166.2,-156},{-166.2,-150}}, color={0,0,127}));
-  connect(t_set_heating29.y, building30.T_setHeating[1]) annotation (Line(points={
-          {-88.4,-188},{-94,-188},{-94,-198},{-100.2,-198}}, color={0,0,127}));
+        points={{-164.4,-144},{-164.4,-148},{-180.2,-148}}, color={0,0,127}));
+  connect(set_airchange25.y, building46.airchange[1]) annotation (Line(points={{-164.4,
+          -156},{-180.2,-156},{-180.2,-150}},        color={0,0,127}));
+  connect(t_set_heating29.y, building30.T_setHeating[1]) annotation (Line(points={{-88.4,
+          -194},{-94,-194},{-94,-198},{-100.2,-198}},        color={0,0,127}));
   connect(t_set_cooling29.y, building30.T_setCooling[1])
-    annotation (Line(points={{-88.4,-200},{-100.2,-200}}, color={0,0,127}));
+    annotation (Line(points={{-88.4,-206},{-94,-206},{-94,-200},{-100.2,-200}},
+                                                          color={0,0,127}));
   connect(set_airchange29.y, building30.airchange[1]) annotation (Line(points={{-88.4,
-          -212},{-94,-212},{-94,-202},{-100.2,-202}}, color={0,0,127}));
+          -218},{-94,-218},{-94,-202},{-100.2,-202}}, color={0,0,127}));
   connect(groundBuilding45.port, building45.toSolidHeatPorts[1])
     annotation (Line(points={{-2,-316},{-2,-312},{-6,-312},{-6,-309}},
                                                      color={191,0,0}));
@@ -2336,16 +2428,16 @@ equation
     annotation (Line(points={{-128,-102},{-128,-98},{-132,-98},{-132,-95}},
                                                        color={191,0,0}));
   connect(groundBuilding6.port, building6.toSolidHeatPorts[1])
-    annotation (Line(points={{-194,-128},{-194,-124},{-198,-124},{-198,-121}},
-                                                         color={191,0,0}));
+    annotation (Line(points={{-198,-130},{-198,-121}},   color={191,0,0}));
   connect(groundBuilding46.port, building46.toSolidHeatPorts[1])
-    annotation (Line(points={{-176,-170},{-176,-166},{-180,-166},{-180,-163}},
+    annotation (Line(points={{-178,-172},{-194,-172},{-194,-163}},
                                                          color={191,0,0}));
   connect(groundBuilding2.port, building2.toSolidHeatPorts[1])
     annotation (Line(points={{-146,-168},{-146,-164},{-150,-164},{-150,-161}},
                                                          color={191,0,0}));
   connect(groundBuilding3.port, building3.toSolidHeatPorts[1]) annotation (Line(
-        points={{-134,-170},{-136,-170},{-136,-141}},     color={191,0,0}));
+        points={{-144,-132},{-140,-132},{-140,-131},{-136,-131}},
+                                                          color={191,0,0}));
   connect(groundBuilding50.port, building50.toSolidHeatPorts[1])
     annotation (Line(points={{-106,-176},{-106,-172},{-110,-172},{-110,-169}},
                                                          color={191,0,0}));
@@ -2409,11 +2501,93 @@ equation
     annotation (Line(points={{-132,182},{-132,186},{-136,186},{-136,189}},
                                                        color={191,0,0}));
 
+  connect(CO2_in11.y, building11.C_in[1]) annotation (Line(points={{7.6,174},{
+          7.6,164},{-4.2,164},{-4.2,147.8}}, color={0,0,127}));
+  connect(CO2_in47.y, building47.C_in[1]) annotation (Line(points={{109.6,70},{
+          109.6,60},{97.8,60},{97.8,47.8}}, color={0,0,127}));
+  connect(CO2_in27.y, building27.C_in[1]) annotation (Line(points={{77.6,98},{
+          65.8,98},{65.8,77.8}}, color={0,0,127}));
+  connect(CO2_in34.y, building34.C_in[1]) annotation (Line(points={{49.6,8},{42,
+          8},{42,39.8},{37.8,39.8}}, color={0,0,127}));
+  connect(CO2_in10.y, building10.C_in[1]) annotation (Line(points={{15.6,100},{
+          15.6,88},{3.8,88},{3.8,77.8}}, color={0,0,127}));
+  connect(CO2_in25.y, building25.C_in[1]) annotation (Line(points={{-30.4,76},{
+          -30.4,64},{-42.2,64},{-42.2,53.8}}, color={0,0,127}));
+  connect(CO2_in14.y, building14.C_in[1]) annotation (Line(points={{-40.4,112},
+          {-52.2,112},{-52.2,93.8}}, color={0,0,127}));
+  connect(building5.C_in[1], CO2_in5.y) annotation (Line(points={{-82.2,107.8},
+          {-82.2,124},{-78.4,124},{-78.4,138}}, color={0,0,127}));
+  connect(CO2_in17.y, building17.C_in[1]) annotation (Line(points={{-134.4,122},
+          {-134.4,112},{-146.2,112},{-146.2,97.8}}, color={0,0,127}));
+  connect(CO2_in40.y, building40.C_in[1]) annotation (Line(points={{-98.4,58},{
+          -98.4,48},{-110.2,48},{-110.2,35.8}}, color={0,0,127}));
+  connect(CO2_in1.y, building1.C_in[1]) annotation (Line(points={{-150.4,72},{
+          -150.4,60},{-162.2,60},{-162.2,49.8}}, color={0,0,127}));
+  connect(CO2_in12.y, building12.C_in[1]) annotation (Line(points={{-152.4,166},
+          {-152.4,156},{-162.2,156},{-162.2,141.8}}, color={0,0,127}));
+  connect(CO2_in16.y, building16.C_in[1]) annotation (Line(points={{-32.4,222},
+          {-32.4,212},{-44.2,212},{-44.2,197.8}}, color={0,0,127}));
+  connect(CO2_in33.y, building33.C_in[1]) annotation (Line(points={{-54.4,250},
+          {-62,250},{-62,228},{-66,228},{-66,227.8},{-66.2,227.8}}, color={0,0,
+          127}));
+  connect(CO2_in21.y, building21.C_in[1]) annotation (Line(points={{-110.4,228},
+          {-122.2,228},{-122.2,207.8}}, color={0,0,127}));
+  connect(CO2_in54.y, building54.C_in[1]) annotation (Line(points={{113.6,-182},
+          {101.8,-182},{101.8,-154.2}}, color={0,0,127}));
+  connect(CO2_in53.y, building53.C_in[1]) annotation (Line(points={{87.6,-220},
+          {77.8,-220},{77.8,-190.2}}, color={0,0,127}));
+  connect(CO2_in29.y, building29.C_in[1]) annotation (Line(points={{129.6,-94},
+          {129.6,-104},{117.8,-104},{117.8,-114.2}}, color={0,0,127}));
+  connect(CO2_in7.y, building7.C_in[1]) annotation (Line(points={{135.6,-42},{
+          135.6,-52},{123.8,-52},{123.8,-66.2}}, color={0,0,127}));
+  connect(CO2_in51.y, building51.C_in[1]) annotation (Line(points={{267.6,-98},
+          {267.6,-108},{255.8,-108},{255.8,-120.2}}, color={0,0,127}));
+  connect(CO2_in39.y, building39.C_in[1]) annotation (Line(points={{319.6,-36},
+          {319.6,-48},{307.8,-48},{307.8,-60.2}}, color={0,0,127}));
+  connect(CO2_in23.y, building23.C_in[1]) annotation (Line(points={{311.6,-110},
+          {311.6,-120},{299.8,-120},{299.8,-132.2}}, color={0,0,127}));
+  connect(CO2_in13.y, building13.C_in[1]) annotation (Line(points={{17.6,-62},{
+          17.6,-72},{5.8,-72},{5.8,-84.2}}, color={0,0,127}));
+  connect(CO2_in9.y, building9.C_in[1]) annotation (Line(points={{-106.4,-54},{
+          -106.4,-64},{-118.2,-64},{-118.2,-76.2}}, color={0,0,127}));
+  connect(CO2_in3.y, building3.C_in[1]) annotation (Line(points={{-110.4,-104},
+          {-120,-104},{-120,-112.2},{-122.2,-112.2}}, color={0,0,127}));
+  connect(CO2_in50.y, building50.C_in[1]) annotation (Line(points={{-84.4,-128},
+          {-92,-128},{-92,-150},{-96,-150},{-96,-150.2},{-96.2,-150.2}}, color=
+          {0,0,127}));
+  connect(CO2_in2.y, building2.C_in[1]) annotation (Line(points={{-126.4,-140},
+          {-126.4,-142.2},{-136.2,-142.2}}, color={0,0,127}));
+  connect(CO2_in6.y, building6.C_in[1]) annotation (Line(points={{-176.4,-82},{
+          -176.4,-92},{-184.2,-92},{-184.2,-102.2}}, color={0,0,127}));
+  connect(CO2_in30.y, building30.C_in[1]) annotation (Line(points={{-88.4,-182},
+          {-96,-182},{-96,-196.2},{-100.2,-196.2}}, color={0,0,127}));
+  connect(CO2_in45.y, building45.C_in[1]) annotation (Line(points={{19.6,-268},
+          {19.6,-280},{7.8,-280},{7.8,-290.2}}, color={0,0,127}));
+  connect(CO2_in48.y, building48.C_in[1]) annotation (Line(points={{189.6,-186},
+          {189.6,-196},{177.8,-196},{177.8,-210.2}}, color={0,0,127}));
+  connect(CO2_in44.y, building44.C_in[1]) annotation (Line(points={{85.6,-274},
+          {85.6,-284},{73.8,-284},{73.8,-294.2}}, color={0,0,127}));
+  connect(CO2_in35.y, building35.C_in[1]) annotation (Line(points={{-314.4,10},
+          {-314.4,0},{-326.2,0},{-326.2,-16.2}}, color={0,0,127}));
+  connect(CO2_in55.y, building55.C_in[1]) annotation (Line(points={{-254.4,126},
+          {-254.4,116},{-266.2,116},{-266.2,103.8}}, color={0,0,127}));
+  connect(CO2_in52.y, building52.C_in[1]) annotation (Line(points={{159.6,-116},
+          {159.6,-128},{147.8,-128},{147.8,-140.2}}, color={0,0,127}));
+  connect(CO2_in43.y, building43.C_in[1]) annotation (Line(points={{-208.4,336},
+          {-208.4,324},{-220.2,324},{-220.2,311.8}}, color={0,0,127}));
+  connect(CO2_in46.y, building46.C_in[1]) annotation (Line(points={{-164.4,-122},
+          {-164,-122},{-164,-132},{-180.2,-132},{-180.2,-144.2}}, color={0,0,
+          127}));
+  connect(CO2_in8.y, building8.C_in[1]) annotation (Line(points={{-34.4,162},{
+          -40.2,162},{-40.2,135.8}}, color={0,0,127}));
   annotation (__Dymola_Commands(file="modelica://BuildingSystems/Resources/Scripts/Dymola/Applications/DistrictSimulation/HCBC.mos" "Simulate and plot"),
     Diagram(coordinateSystem(extent={{-400,-400},{400,400}},preserveAspectRatio=false),
-    graphics={Bitmap(extent={{-398,-402},{396,400}},
+    graphics={Bitmap(extent={{-398,-404},{396,398}},
     fileName="modelica://BuildingSystems/Resources/Images/Applications/DistrictSimulation/HCBCBackground.png")}),
-    experiment(StopTime=864000),
+    experiment(
+      StopTime=31536000,
+      Interval=3600,
+      __Dymola_Algorithm="Dassl"),
     __Dymola_experimentSetupOutput(events=false),
 Documentation(info="<html>
 <p>

--- a/BuildingSystems/Applications/DistrictSimulation/package.order
+++ b/BuildingSystems/Applications/DistrictSimulation/package.order
@@ -2,3 +2,4 @@ BaseClasses
 DistrictBerlinKreuzberg
 HCBC
 HCBC_DHN
+HCBC_Comfort

--- a/BuildingSystems/Buildings/Airvolumes/AirvolumeMixedCO2.mo
+++ b/BuildingSystems/Buildings/Airvolumes/AirvolumeMixedCO2.mo
@@ -1,0 +1,181 @@
+within BuildingSystems.Buildings.Airvolumes;
+model AirvolumeMixedCO2
+  "Ideal-mixed air volume model for moist air with CO2 concentration"
+  extends BuildingSystems.Buildings.BaseClasses.AirvolumeGeneral(
+  redeclare package Medium = BuildingSystems.Media.Air(extraPropertiesNames={"CO2"}),
+  final nAirElements = 1);
+  parameter Integer nHeatSources = 0
+    "Number of heat convective sources"
+    annotation(Evaluate=true, Dialog(connectorSizing=true, tab="General",group="Ports"));
+  parameter Integer nMoistureSources = 0
+    "Number of moisture sources"
+    annotation(Evaluate=true, Dialog(connectorSizing=true, tab="General",group="Ports"));
+  BuildingSystems.Types.RelativeHumidity phi
+    "Relative humidity of the air";
+  Modelica.Units.SI.Mass mH2OLiq(
+    start = mH2OLiq_start)
+    "Liquid water mass";
+  parameter Modelica.Units.SI.Mass mH2OLiq_start = 0.0
+   "Liquid water mass (start value)"
+    annotation (Dialog(tab="Initialization"));
+  BuildingSystems.Interfaces.HeatPorts heatSourcesPorts[nHeatSources]
+    "Heat ports of the convective heat sources"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=90,origin={-80,40}),
+      iconTransformation(extent={{-40,-10},{40,10}},rotation=90,origin={-80,40})));
+  BuildingSystems.Interfaces.MoisturePorts moistureSourcesPorts[nMoistureSources]
+    "Moisture ports of the moisture sources"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=270,origin={-80,-40}),
+      iconTransformation(extent={{-40,-10},{40,10}},rotation=90,origin={-80,-40})));
+  parameter BuildingSystems.Buildings.Types.DataSource TSou=
+   BuildingSystems.Buildings.Types.DataSource.Calculation
+    "Data source for air temperature"
+    annotation (Evaluate=true, Dialog(tab="Advanced", group="Data source"));
+  parameter Modelica.Units.SI.Temperature T_constant = 293.15
+    "Constant air temperature (used if TSou=Parameter)"
+    annotation (Dialog(tab="Advanced", group="Data source"));
+  BuildingSystems.Interfaces.Temp_KInput T_in if
+       TSou == BuildingSystems.Buildings.Types.DataSource.Input
+    "Prediscribed external air temperature (used if TSou=Input)"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={80,40}),
+      iconTransformation(extent={{90,30},{70,50}})));
+  parameter BuildingSystems.Buildings.Types.DataSource xSou=
+   BuildingSystems.Buildings.Types.DataSource.Calculation
+    "Data source for air moisture"
+    annotation (Evaluate=true, Dialog(tab="Advanced", group="Data source"));
+  parameter Modelica.Units.SI.MassFraction x_constant = 0.005
+    "Vonstant air moisture (used if xSou=Parameter)"
+    annotation (Dialog(tab="Advanced", group="Data source"));
+  BuildingSystems.Interfaces.Moisture_absInput x_in if
+       xSou == BuildingSystems.Buildings.Types.DataSource.Input
+    "Prediscribed external air moisture (used if xSou=Input)"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={80,0}),
+      iconTransformation(extent={{90,-10},{70,10}})));
+  constant Modelica.Units.SI.Velocity vAir_constant = 0.0
+    "Air velocity";
+  constant Modelica.Units.NonSI.Angle_deg angleDegAir_constant = 0.0
+    "Direction of the air flow";
+  BuildingSystems.Buildings.Airvolumes.MixingVolumeMoistAir air(
+    redeclare package Medium = Medium,
+    C_start={0.0004},
+    geometryType=geometryType,
+    V=V,
+    m_flow_nominal=0.1,
+    use_C_flow=true,
+    nPorts=nAirpaths,
+    T_start=T_start[1],
+    X_start={x_start[1],1-x_start[1]},
+    energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial,
+    massDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial) if
+       TSou == BuildingSystems.Buildings.Types.DataSource.Calculation
+    "Mixed air volume of moist air"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  Modelica.Thermal.HeatTransfer.Sensors.TemperatureSensor senTem if
+       TSou == BuildingSystems.Buildings.Types.DataSource.Calculation
+    annotation (Placement(transformation(extent={{-10,-30},{-30,-10}})));
+  Modelica.Blocks.Sources.RealExpression pAir(
+    y=air.p)
+    annotation (Placement(transformation(extent={{44,50},{64,70}})));
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow prescribedHeatFlow
+    annotation (Placement(transformation(extent={{-36,-6},{-24,6}})));
+  Modelica.Blocks.Sources.RealExpression QSum_flow(
+    y=sum(toSurfacePorts.heatPort.Q_flow)+sum(heatSourcesPorts.Q_flow))
+    annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+  Modelica.Blocks.Sources.RealExpression mWatSum_flow(
+    y=sum(toSurfacePorts.moisturePort.m_flow)
+      + (-0.5 * Modelica.Math.tanh(100.0*(phi-1.0)) + 0.5) * sum(moistureSourcesPorts.m_flow)
+      + BuildingSystems.Utilities.SmoothFunctions.softcut(1.0-phi,0.0,1.0,0.001) * mH2OLiq)
+    annotation (Placement(transformation(extent={{-40,10},{-20,30}})));
+                                              // water vaper from moisture transfer of surfaces
+                                                                                              // water vapor from moisture sources
+                                                                                            // evaporated water from liquid reservoir
+  Modelica.Blocks.Interfaces.RealInput C_in "Input port for concentration"
+    annotation (Placement(transformation(extent={{94,-70},{74,-50}}),
+        iconTransformation(extent={{66,-70},{86,-50}})));
+equation
+  // Select source for air temperature
+  if TSou == BuildingSystems.Buildings.Types.DataSource.Parameter then
+    T[1] = T_constant;
+  elseif TSou == BuildingSystems.Buildings.Types.DataSource.Calculation then
+    connect(T[1], senTem.T)
+    annotation (Line(points={{80,20},{-40,20},{-40,-40},{60,-40},{60,-20},{-30,
+            -20}},                                                                    color={0,0,127}));
+  else
+    connect(T[1], T_in);
+  end if;
+
+  // Select source for air moisture
+  if xSou == BuildingSystems.Buildings.Types.DataSource.Parameter then
+    x[1] = x_constant;
+  elseif TSou == BuildingSystems.Buildings.Types.DataSource.Calculation then
+    connect(x[1], air.X_w)
+      annotation (Line(points={{80,-20},{50,-20},{50,-4},{12,-4}},color={0,0,127}));
+  else
+    connect(x[1], x_in);
+  end if;
+
+  // Boundary conditions for heat sources of the air volume
+  for i in 1:nHeatSources loop
+    heatSourcesPorts[i].T = T[1];
+  end for;
+
+  // Boundary conditions for moisture sources of the air volume
+  for i in 1:nMoistureSources loop
+    moistureSourcesPorts[i].x = x[1];
+  end for;
+
+  // Boundary conditions for all surfaces of the air volume
+  for i in 1:nSurfaces loop
+    toSurfacePorts[i].heatPort.T = T[1];
+    toSurfacePorts[i].moisturePort.x = x[1];
+    toSurfacePorts[i].angleDegAir = angleDegAir_constant;
+    toSurfacePorts[i].vAir = vAir_constant;
+  end for;
+
+  phi = BuildingSystems.Utilities.Psychrometrics.Functions.phi_pTX(100000,T[1],x[1]);
+
+  // Mass balance of liquid water
+   der(mH2OLiq) = (1.0 - (-0.5 * Modelica.Math.tanh(100.0*(phi-1.0)) + 0.5)) * sum(moistureSourcesPorts.m_flow)
+    - BuildingSystems.Utilities.SmoothFunctions.softcut(1.0-phi,0.0,1.0,0.001) * mH2OLiq;                       // water vapor surplus from moisture sources if relative moisture becomes close to 1
+                                                                                          // evaporated water which leaves the liquid reservoir
+
+  connect(V_in, air.V_in)
+    annotation (Line(points={{-80,0},{-64,0},{-64,10},{-20,10},{-20,4},{-12,4}},color={0,0,127}));
+  connect(air.ports, airpathPorts)
+    annotation (Line(points={{0,-10},{-4.44089e-16,-10},{-4.44089e-16,-80}}, color={0,127,255}));
+  connect(air.heatPort, prescribedHeatFlow.port)
+    annotation (Line(points={{-10,0},{-24,0}}, color={191,0,0}));
+  connect(prescribedHeatFlow.Q_flow, QSum_flow.y)
+    annotation (Line(points={{-36,0},{-39,0}}, color={0,0,127}));
+  connect(mWatSum_flow.y, air.mWat_flow)
+    annotation (Line(points={{-19,20},{-16,20},{-16,8},{-12,8}}, color={0,0,127}));
+  connect(senTem.port, air.heatPort)
+    annotation (Line(points={{-10,-20},{-10,0}}, color={191,0,0}));
+  connect(pAir.y, p[1])
+    annotation (Line(points={{65,60},{80,60}}, color={0,0,127}));
+
+  connect(C_in, air.C_flow[1]) annotation (Line(points={{84,-60},{-48,-60},{-48,
+          -6},{-12,-6}}, color={0,0,127}));
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100}, {100,100}}), graphics={
+    Text(extent={{-18,71},{50,5}},lineColor={255,128,0},lineThickness=0.5,fillColor={255,128,0},
+            fillPattern =                                                                                   FillPattern.Solid,textString
+            =                                                                                                                            "D"),
+    Text(extent={{-52,71},{16,5}},lineColor={255,128,0},lineThickness=0.5,fillColor={255,128,0},
+            fillPattern =                                                                                   FillPattern.Solid,textString
+            =                                                                                                                            "0")}),
+Documentation(info="<html>
+<p>
+This is a model of an ideal-mixed air volume for moist air.
+</p>
+</html>", revisions="<html>
+<ul>
+<li>
+October 28, 2020 by Christoph Nytsch-Geusen:<br/>
+Adaptation zti IBPSA library.
+</li>
+<li>
+May 23, 2015 by Christoph Nytsch-Geusen:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end AirvolumeMixedCO2;

--- a/BuildingSystems/Buildings/Airvolumes/package.order
+++ b/BuildingSystems/Buildings/Airvolumes/package.order
@@ -1,5 +1,6 @@
 Airvolume3DTemplate
 AirvolumeMixed
+AirvolumeMixedCO2
 MixingVolumeMoistAir
 AirElements
 FlowConnections

--- a/BuildingSystems/Buildings/Ambience.mo
+++ b/BuildingSystems/Buildings/Ambience.mo
@@ -15,6 +15,9 @@ model Ambience
   parameter Boolean calcLwRad = true
     "True: long-wave radiation exchange on building surfaces is considered; false: no long-wave radiation exchange"
     annotation(HideResult = true,Dialog(tab = "General", group = "Surfaces"));
+  parameter Boolean useSolarMask = false
+    "True: attenuation of direct solar radiation by the building's environment is considered; false: solar radiation is not attenuated"
+    annotation(HideResult = true,Dialog(tab = "General", group = "Surfaces"));
   parameter Integer nAirpaths = 0
     "Number of airpaths to the building"
     annotation(HideResult=true, Dialog(tab = "General", group = "Airpaths"));
@@ -113,6 +116,11 @@ model Ambience
     "Solar beam radiation of horizontal surface from input"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=90,origin={-28,-74}),
       iconTransformation(extent={{10,-10},{-10,10}},rotation=270,origin={-30,-90})));
+
+  // Solar masks
+  BuildingSystems.Buildings.BaseClasses.ShadowingElementEnvironmentGeneral solarmask[nSurfaces]
+    "Radiation modified by solar masks in the environment surrounding the building"
+    annotation(Placement(transformation(extent={{60,32.5},{75,47.5}})));
 
   // Solar diffuse radiation of horizontal surface
   parameter BuildingSystems.Buildings.Types.DataSource IrrDifHorSou = BuildingSystems.Buildings.Types.DataSource.Calculation
@@ -243,10 +251,25 @@ equation
     else
       toSurfacePorts[i].heatPortLw.Q_flow = 0.0;
     end if;
-    toSurfacePorts[i].heatPortSw.Q_flow = - toSurfacePorts[i].abs *
-      (radiation[i].radiationPort.IrrDir + radiation[i].radiationPort.IrrDif) * toSurfacePorts[i].A;
-    connect(radiation[i].radiationPort, toSurfacePorts[i].radiationPort_in)
-      annotation (Line(points={{52,11.8},{52,40},{80,40}},color={0,0,0},pattern=LinePattern.Solid,smooth=Smooth.None));
+    if useSolarMask then
+      toSurfacePorts[i].heatPortSw.Q_flow = - toSurfacePorts[i].abs *
+        (solarmask[i].radiationPort_out.IrrDir + solarmask[i].radiationPort_out.IrrDif) * toSurfacePorts[i].A;
+      connect(radiation[i].radiationPort, solarmask[i].radiationPort_in)
+        annotation (Line(points={{52,11.8},{52,40},{62.5,40}},color={0,0,0},pattern=LinePattern.Solid,smooth=Smooth.None));
+      connect(solarmask[i].radiationPort_out, toSurfacePorts[i].radiationPort_in)
+        annotation (Line(points={{75,40},{80,40}},color={0,0,0},pattern=LinePattern.Solid,smooth=Smooth.None));
+    else
+      solarmask[i].SC = 1.0;
+      solarmask[i].radiationPort_in.IrrDir = 0.0;
+      solarmask[i].radiationPort_in.IrrDif = 0.0;
+      solarmask[i].radiationPort_in.angleDegInc = 0.0;
+      solarmask[i].radiationPort_in.angleDegAziSun = 0.0;
+      solarmask[i].radiationPort_in.angleDegHeightSun = 0.0;
+      toSurfacePorts[i].heatPortSw.Q_flow = - toSurfacePorts[i].abs *
+        (radiation[i].radiationPort.IrrDir + radiation[i].radiationPort.IrrDif) * toSurfacePorts[i].A;
+      connect(radiation[i].radiationPort, toSurfacePorts[i].radiationPort_in)
+        annotation (Line(points={{52,11.8},{52,40},{80,40}},color={0,0,0},pattern=LinePattern.Solid,smooth=Smooth.None));
+    end if;
   end for;
   // Air path calculation
   for i in 1:nAirpaths loop

--- a/BuildingSystems/Buildings/BaseClasses/ShadowingElementEnvironmentGeneral.mo
+++ b/BuildingSystems/Buildings/BaseClasses/ShadowingElementEnvironmentGeneral.mo
@@ -1,0 +1,42 @@
+within BuildingSystems.Buildings.BaseClasses;
+model ShadowingElementEnvironmentGeneral
+  "Abstract model class of a shadowing element of the building's environment"
+  BuildingSystems.Interfaces.RadiationPort radiationPort_in
+    annotation (Placement(transformation(extent={{-50,-10},{-30,10}}),
+      iconTransformation(extent={{-50,-10},{-30,10}})));
+  BuildingSystems.Interfaces.RadiationPort radiationPort_out
+    annotation (Placement(transformation(extent={{30,-10},{50,10}}),
+      iconTransformation(extent={{30,-10},{50,10}})));
+  Modelica.Blocks.Interfaces.RealInput SC(min = 0.0, max = 1.0)
+    "Shading coefficient"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=-90,origin={0,-70}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=-90,origin={0,-90})));
+  parameter Boolean maskIrrDif = true
+    "True: the shading coefficient is applied to diffuse irradiation"
+    annotation(HideResult = true,Dialog(tab = "Advanced", group = "Shading Mask"));
+equation
+  if maskIrrDif then
+    radiationPort_out.IrrDif = SC * radiationPort_in.IrrDif;
+  else
+    radiationPort_out.IrrDif = radiationPort_in.IrrDif;
+  end if;
+  radiationPort_out.IrrDir = SC * radiationPort_in.IrrDir;
+  radiationPort_out.angleDegInc = radiationPort_in.angleDegInc;
+  radiationPort_out.angleDegAziSun = radiationPort_in.angleDegAziSun;
+  radiationPort_out.angleDegHeightSun = radiationPort_in.angleDegHeightSun;
+
+annotation (
+  Icon(graphics={Rectangle(extent={{-40,80},{40,-80}}, lineColor={0,0,0})}),
+Documentation(info="<html>
+<p>
+This is an abstract model of a shadowing element of the building's environment.
+</p>
+</html>", revisions="<html>
+<ul>
+<li>
+October 3, 2023 by Philippe Pinçon:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end ShadowingElementEnvironmentGeneral;

--- a/BuildingSystems/Buildings/BaseClasses/ZoneTemplateGeneralCO2.mo
+++ b/BuildingSystems/Buildings/BaseClasses/ZoneTemplateGeneralCO2.mo
@@ -1,0 +1,160 @@
+within BuildingSystems.Buildings.BaseClasses;
+partial model ZoneTemplateGeneralCO2
+  "Template model of a thermal zone"
+  parameter String IfcId="";
+  replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
+    "Medium in the air model of the zone"
+    annotation (choicesAllMatching = true);
+  input BuildingSystems.Interfaces.ViewFactorInput ViewFac_in[nSurfaces,nSurfaces]
+    if viewFacCalcType==BuildingSystems.Buildings.Types.ViewFactorCalculationType.Input
+    annotation (Placement(transformation(extent={{-120,80},{-100,100}}),
+      iconTransformation(extent={{-120,80},{-100,100}})));
+  parameter BuildingSystems.Buildings.Types.GeometryType geometryType=
+    BuildingSystems.Buildings.Types.GeometryType.Fixed
+    "Fixed (default) or flexible geometry"
+    annotation (Evaluate=true, Dialog(tab = "Geometry", group = "Zone geometry"));
+  parameter Modelica.Units.SI.Volume V=1.0
+    "Air volume of the zone (if geometryType == Fixed)"
+    annotation (Dialog(tab="Geometry", group="Zone geometry"));
+  input BuildingSystems.Interfaces.VolumeInput V_in(
+    min=0) if geometryType == BuildingSystems.Buildings.Types.GeometryType.Flexible
+    "Air volume of the zone from input"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=0,  origin={-110,0}),
+      iconTransformation(extent={{10,-10},{-10,10}},rotation=180,origin={-110,0})));
+  parameter Modelica.Units.SI.Length position[3]={0.0,0.0,0.0}
+    "Position (if geometryType == Fixed)"
+    annotation (Dialog(tab="Geometry", group="Zone geometry"));
+  input BuildingSystems.Interfaces.LengthInput position_in[3]
+    if geometryType == BuildingSystems.Buildings.Types.GeometryType.Flexible
+    "Position from input"
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={-110,20}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={-110,20})));
+  output BuildingSystems.Interfaces.LengthOutput position_internal[3]
+    "Position"
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={110,20}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,origin={110,50})));
+  parameter Modelica.Units.SI.Length height=1.0 "Vertical height of the zone"
+    annotation (Dialog(tab="General", group="Air change"));
+  parameter BuildingSystems.HAM.ConvectiveHeatTransfer.Types.Convection convectionOnSurfaces = BuildingSystems.HAM.ConvectiveHeatTransfer.Types.Convection.const
+    "Type of convection calculation of the zone surfaces"
+    annotation(Dialog(tab="Advanced",group="Convection model on building facades"));
+  parameter Modelica.Units.SI.SurfaceCoefficientOfHeatTransfer alphaConstant=
+      1.0 "Convective heat transfer coefficient for simplified calculations"
+    annotation (Dialog(tab="Advanced", group=
+          "Convection model on building facades"));
+  parameter Integer nMoistureSources = 0
+    "Number of internal moisture sources of the thermal zone"
+    annotation(Evaluate=true, Dialog(connectorSizing=true, tab="General",group="Ports"));
+  parameter Integer nConstructions = 0
+    "Number of constructions"
+    annotation(HideResult = true, Evaluate=true, Dialog(connectorSizing=true, tab="General",group="Ports"));
+  parameter Integer nAirpaths = 0
+   "Number of external air paths"
+    annotation(HideResult = true, Evaluate=true, Dialog(connectorSizing=true, tab="General",group="Ports"));
+  parameter Boolean prescribedAirchange = true
+    "True: zone air change rate is prescribed by zone ambience; false: air path calculation"
+    annotation(HideResult = true, Dialog(tab="General",group="Air change"));
+  parameter BuildingSystems.Buildings.Types.ViewFactorCalculationType viewFacCalcType=
+      BuildingSystems.Buildings.Types.ViewFactorCalculationType.AreaWeighted
+      "Surface area weighted (default), geometric view factors or external calculated view factors"
+      annotation (Evaluate=true, Dialog(tab = "Geometry", group = "View Factors"));
+  parameter BuildingSystems.Types.ViewFactor ViewFac[nSurfaces,nSurfaces]=fill(fill(0.0,nSurfaces),nSurfaces)
+    "Geometric view factor matrix of the thermal zone"
+    annotation(HideResult = true,Dialog(tab="Geometry",group="View Factors"));
+  BuildingSystems.Buildings.Interfaces.SurfaceToConstructionPorts toConstructionPorts[nConstructions](
+      moisturePort(x(each start = 0.005)))
+    "Interfaces of the zone to the constructions"
+    annotation (Placement(transformation(extent={{-8,-8},{8,8}},rotation=180,origin={0,0}),
+      iconTransformation(extent={{-20,-20},{20,20}})));
+  Modelica.Fluid.Vessels.BaseClasses.VesselFluidPorts_b airpathPorts[nAirpaths](
+    redeclare each final package Medium = Medium(extraPropertiesNames={"CO2"})) if not prescribedAirchange
+    "Interfaces of the zone to the air paths"
+    annotation (Placement(transformation(extent={{-40,-10},{40,10}},origin={-94,-60}, rotation=270),
+      iconTransformation(extent={{-40,-10},{40,10}},rotation=180,origin={-60,110})));
+  BuildingSystems.Interfaces.Temp_KOutput TSurfMean
+    "Mean surface temperature of the zone"
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={40,-60}),
+     iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,-30})));
+protected
+  output BuildingSystems.Interfaces.VolumeOutput V_internal
+    "Air volume of the zone";
+  output BuildingSystems.Interfaces.ViewFactorOutput ViewFac_internal[nSurfaces,nSurfaces]
+    "View factors of the zone";
+  BuildingSystems.Buildings.BaseClasses.RadiationDistribution radiationDistribution(
+    nSurfaces=nSurfaces,
+    nHeatSources=nHeatSourcesTotal)
+    "Long-wave and short-wave radiation calculation of the zone"
+    annotation (Placement(transformation(extent={{-24,-84},{24,-36}})));
+  BuildingSystems.Buildings.Surfaces.SurfacesToAir surfaces(
+    nSurfaces=nConstructions,
+    surface(each convectionOnSurface = convectionOnSurfaces,
+            each alphaConstant = alphaConstant))
+    "surface models of the zone"
+    annotation (Placement(transformation(extent={{-24,-26},{24,26}},origin={-80,40})));
+  parameter Integer nHeatSourcesTotal = 0
+    "Overall number of internal heat sources of the thermal zone";
+  // Note, that with following three lines it is assumed, that there is always at least ONE construction!
+  parameter Integer nSurfaces = max(nConstructions,1)
+    "Overall number of surfaces of the zone";
+  parameter Integer nAirpathsInternal = if prescribedAirchange then 2 else + nAirpaths
+    "Overall number of air paths of the zone";
+  constant Modelica.Units.SI.Density rho_nominal=1.2
+    "Air density under nominal conditions";
+equation
+  if viewFacCalcType == BuildingSystems.Buildings.Types.ViewFactorCalculationType.AreaWeighted then
+    for i in 1:nSurfaces loop
+      for j in 1:nSurfaces loop
+        ViewFac_internal[i,j] = surfaces.toSurfacesPorts[j].A/sum(surfaces.toSurfacesPorts[k].A for k in 1:nSurfaces);
+      end for;
+    end for;
+  elseif viewFacCalcType == BuildingSystems.Buildings.Types.ViewFactorCalculationType.Geometrical then
+    ViewFac_internal = ViewFac;
+  else
+    connect(ViewFac_internal, ViewFac_in);
+  end if;
+  radiationDistribution.F = ViewFac_internal;
+
+  if geometryType == BuildingSystems.Buildings.Types.GeometryType.Fixed then
+    V_internal = V;
+    position_internal = position;
+  else
+    connect(V_internal, V_in);
+    connect(position_internal, position_in);
+  end if;
+
+  for i in 1:nConstructions loop
+    connect(surfaces.toConstructionPorts[i],toConstructionPorts[i]);
+    connect(surfaces.toSurfacesPorts[i],radiationDistribution.toSurfacePorts[i]);
+  end for;
+  connect(radiationDistribution.TSurfMean, TSurfMean)
+    annotation (Line(points={{19.2,-60},{40,-60}}, color={0,0,127}));
+
+  annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
+    Rectangle(extent={{-80,80},{80,-80}},lineColor={230,230,230},fillColor={230,230,230},fillPattern = FillPattern.Solid),
+    Text(extent={{-46,-132},{46,-160}},lineColor={0,0,255},fillColor={230,230,230},fillPattern = FillPattern.Solid,textString="%name"),
+  Rectangle(extent={{100,100},{80,-100}},lineColor={255,170,85},fillColor={255,170,85},fillPattern = FillPattern.Solid),
+  Rectangle(extent={{-80,100},{-100,-100}},lineColor={255,170,85},fillColor={255,170,85},fillPattern = FillPattern.Solid),
+  Rectangle(extent={{-80,100},{80,80}}, lineColor={255,170,85},fillColor={255,170,85},fillPattern = FillPattern.Solid),
+  Rectangle(extent={{-80,-80},{80,-100}},lineColor={255,170,85},fillColor={255,170,85},fillPattern = FillPattern.Solid)}),
+Documentation(info="<html>
+<p>
+This is a template model of a thermal zone.
+</p>
+</html>", revisions="<html>
+<ul>
+<li>
+May 14, 2022 by Christoph Nytsch-Geusen:<br/>
+Extension for an optional input for external view factor calculation.
+</li>
+<li>
+<li>
+April 24, 2019 by Christoph Nytsch-Geusen:<br/>
+Adaptation to flexible geometries.
+</li>
+<li>
+May 23, 2015 by Christoph Nytsch-Geusen:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end ZoneTemplateGeneralCO2;

--- a/BuildingSystems/Buildings/BaseClasses/package.order
+++ b/BuildingSystems/Buildings/BaseClasses/package.order
@@ -17,4 +17,5 @@ WallThermalTriangularGeneral
 WallTriangularGeneral
 WindowGeneral
 ZoneTemplateGeneral
+ZoneTemplateGeneralCO2
 OpaqueConstruction

--- a/BuildingSystems/Buildings/BaseClasses/package.order
+++ b/BuildingSystems/Buildings/BaseClasses/package.order
@@ -7,6 +7,7 @@ HeatConduction3DWithTube
 PartialMixingVolume
 RadiationDistribution
 RelationRadiationConvection
+ShadowingElementEnvironmentGeneral
 ShadowingElementGeneral
 SurfaceGeneral
 TriangularConstructionGeneral

--- a/BuildingSystems/Buildings/Comfort/ThermalComfortConnector.mo
+++ b/BuildingSystems/Buildings/Comfort/ThermalComfortConnector.mo
@@ -1,0 +1,46 @@
+within BuildingsSystems.Buildings.Comfort;
+model ThermalComfortConnector
+  "Model for dynamically connecting comfort input variables with a Thermal Comfort model."
+  Modelica.Blocks.Interfaces.RealInput clo_in(min = 0.0, max = 2.0)
+    "Clothing input";
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+  Modelica.Blocks.Interfaces.RealInput met_in(min = 0.7, max = 7.0)
+    "Metabolism rate input";
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+  Modelica.Blocks.Interfaces.RealInput wme_in(min = 0.0, max = 10.0)
+    "External work input";
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+  Modelica.Blocks.Interfaces.RealInput vAir_in(min = 0.0, max = 1.0)
+    "Mean relative air velocity in the area of the user presence input";
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+  Modelica.Blocks.Interfaces.RealOutput clo_out
+    "Clothing output";
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+  Modelica.Blocks.Interfaces.RealOutput met_out
+    "Metabolism rate output";
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+  Modelica.Blocks.Interfaces.RealOutput wme_out
+    "External work output";
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+  Modelica.Blocks.Interfaces.RealOutput vAir_out
+    "Mean relative air velocity in the area of the user presence output";
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+
+equation
+  clo_out = clo_in;
+  met_out = met_in;
+  wme_out = wme_in;
+  vAir_out = vAir_in;
+
+annotation (Documentation(info="<html>
+<p> This connector is used for to dynamically connect thermal comfort variables.
+</p>
+</html>", revisions="<html>
+<ul>
+<li>
+November 7, 2023 by Philippe Pinçon:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end ThermalComfortConnector;

--- a/BuildingSystems/Buildings/Comfort/ThermalComfortConnector.mo
+++ b/BuildingSystems/Buildings/Comfort/ThermalComfortConnector.mo
@@ -1,4 +1,4 @@
-within BuildingsSystems.Buildings.Comfort;
+within BuildingSystems.Buildings.Comfort;
 model ThermalComfortConnector
   "Model for dynamically connecting comfort input variables with a Thermal Comfort model."
   Modelica.Blocks.Interfaces.RealInput clo_in(min = 0.0, max = 2.0)

--- a/BuildingSystems/Buildings/Comfort/package.order
+++ b/BuildingSystems/Buildings/Comfort/package.order
@@ -1,3 +1,4 @@
 ThermalComfort_DIN_EN_ISO_7730
+ThermalComfortConnector
 Functions
 Examples

--- a/BuildingSystems/Buildings/Constructions/Shadowing/Examples/MaskedBuilding.mo
+++ b/BuildingSystems/Buildings/Constructions/Shadowing/Examples/MaskedBuilding.mo
@@ -1,0 +1,312 @@
+within BuildingSystems.Buildings.Constructions.Shadowing.Examples;
+model MaskedBuilding
+  "Masked building model"
+  extends Modelica.Icons.Example;
+  model Building
+    "Building model with four walls, one window, one ceiling and one floor"
+    extends BuildingSystems.Buildings.BaseClasses.BuildingTemplate(
+      nIdealLoads = 0,
+      nZones=1,
+      prescribedAirchange = false,
+      surfacesToAmbience(nSurfaces=6),
+      nSurfacesSolid = 1,
+      surfacesToSolids(nSurfaces = nSurfacesSolid),
+      useAirPaths = false,
+      nAirpaths = 0,
+      calcIdealLoads = false,
+      convectionOnSurfaces = BuildingSystems.HAM.ConvectiveHeatTransfer.Types.Convection.forced);
+
+    parameter Modelica.Units.SI.Length width = 10.0
+      "Width of the building (inner space)"
+      annotation (Dialog(tab="General", group="Geometry"));
+    parameter Modelica.Units.SI.Length length = 10.0
+      "Length of the building (inner space)"
+      annotation (Dialog(tab="General", group="Geometry"));
+    parameter Modelica.Units.SI.Length height = 2.8
+      "Height of the building (inner space)"
+      annotation (Dialog(tab="General", group="Geometry"));
+    parameter Modelica.Units.SI.Temperature TWall_start = 283.15
+      "Start temperature of each layer of wall1"
+      annotation (Dialog(tab="Initialization", group="Opaque constructions"));
+    parameter Modelica.Units.SI.Temperature TCeiling_start = 283.15
+      "Start temperature of each layer of wall1"
+      annotation (Dialog(tab="Initialization", group="Opaque constructions"));
+    parameter Modelica.Units.SI.Temperature TBottom_start = 283.15
+      "Start temperature of each layer of wall1"
+      annotation (Dialog(tab="Initialization", group="Opaque constructions"));
+    parameter Modelica.Units.SI.Temperature TAir_start = 283.15
+      "Start temperature of indoor air temperature"
+      annotation (Dialog(tab="Initialization"));
+
+    BuildingSystems.Buildings.Zones.ZoneTemplateAirvolumeMixed zone(
+      nConstructions=7,
+      V = width*length*height,
+      height = height,
+      T_start = 281.15,
+      calcIdealLoads = calcIdealLoads,
+      nHeatSources = 0,
+      heatSources = false,
+      prescribedAirchange = prescribedAirchange,
+      convectionOnSurfaces = BuildingSystems.HAM.ConvectiveHeatTransfer.Types.Convection.free)
+      "Thermal zone with fully mixed air volume"
+      annotation (Placement(transformation(extent={{-20,-20},{20,20}})));
+
+    BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction constructionWall1(
+      nLayers=1,
+      thickness={0.15},
+      material={BuildingSystems.HAM.Data.MaterialProperties.Thermal.Concrete()})
+      "Data of the thermal construction"
+      annotation(Dialog(tab = "Opaque constructions", group = "Exterior constructions"), choicesAllMatching=true);
+    BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction constructionWall2(
+      nLayers=1,
+      thickness={0.15},
+      material={BuildingSystems.HAM.Data.MaterialProperties.Thermal.Concrete()})
+      "Data of the thermal construction"
+      annotation(Dialog(tab = "Opaque constructions", group = "Exterior constructions"), choicesAllMatching=true);
+    BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction constructionWall3(
+      nLayers=1,
+      thickness={0.15},
+      material={BuildingSystems.HAM.Data.MaterialProperties.Thermal.Concrete()})
+      "Data of the thermal construction"
+      annotation(Dialog(tab = "Opaque constructions", group = "Exterior constructions"), choicesAllMatching=true);
+    BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction constructionWall4(
+      nLayers=1,
+      thickness={0.15},
+      material={BuildingSystems.HAM.Data.MaterialProperties.Thermal.Concrete()})
+      "Data of the thermal construction"
+      annotation(Dialog(tab = "Opaque constructions", group = "Exterior constructions"), choicesAllMatching=true);
+    BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction constructionCeiling(
+      nLayers=1,
+      thickness={0.1},
+      material={BuildingSystems.HAM.Data.MaterialProperties.Thermal.Concrete()})
+      "Data of the thermal construction"
+      annotation(Dialog(tab = "Opaque constructions", group = "Exterior constructions"), choicesAllMatching=true);
+    BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction constructionBottom(
+      nLayers=1,
+      thickness={0.3},
+      material={BuildingSystems.HAM.Data.MaterialProperties.Thermal.Concrete()})
+      "Data of the thermal construction"
+      annotation(Dialog(tab = "Opaque constructions", group = "Exterior constructions"), choicesAllMatching=true);
+
+    BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall_1(
+      constructionData = constructionWall1,
+      width = width,
+      height = height,
+      T_start = {TWall_start},
+      angleDegAzi = 0.0,
+      angleDegTil = 90.0,
+      epsilon_2 = 0.93,
+      epsilon_1 = 0.93,
+      abs_1 = 0.0,
+      abs_2 = 0.4)
+      "Wall 1 : Thermal wall model with 1D discretisation of the single layers"
+    annotation (Dialog(tab = "Opaque constructions", group = "model type"),
+      Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={-30,-60})));
+    
+    BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall_2(
+      constructionData = constructionWall2,
+      width = length,
+      height = height,
+      T_start = {TWall_start},
+      angleDegAzi = 90.0,
+      angleDegTil = 90.0,
+      epsilon_2 = 0.93,
+      epsilon_1 = 0.93,
+      abs_1 =  0.0,
+      abs_2 = 0.4)
+      "Wall 2 : Thermal wall model with 1D discretisation of the single layers"
+    annotation (Dialog(tab = "Opaque constructions", group = "model type"),
+      Placement(transformation(extent={{-20,-20},{20,20}},rotation=180,origin={-60,0})));
+
+    BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall_3(
+      constructionData = constructionWall3,
+      width = width,
+      height = height,
+      T_start = {TWall_start},
+      angleDegAzi = 180.0,
+      angleDegTil = 90.0,
+      epsilon_2 = 0.93,
+      epsilon_1 = 0.93,
+      abs_1 =  0.0,
+      abs_2 = 0.4)
+      "Wall 3 : Thermal wall model with 1D discretisation of the single layers"
+    annotation (Dialog(tab = "Opaque constructions", group = "model type"),
+      Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={-30,60})));
+
+    BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall_4(
+      constructionData = constructionWall4,
+      width = length,
+      height = height,
+      T_start = {TWall_start},
+      angleDegAzi = -90.0,
+      angleDegTil = 90.0,
+      epsilon_2 = 0.93,
+      epsilon_1 = 0.93,
+      abs_1 =  0.0,
+      abs_2 = 0.4)
+      "Wall 4 : Thermal wall model with 1D discretisation of the single layers"
+    annotation (Dialog(tab = "Opaque constructions", group = "model type"),
+      Placement(transformation(extent={{-20,-20},{20,20}},rotation=0,origin={60,30})));
+
+    BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes ceiling(
+      constructionData = constructionCeiling,
+      width = width,
+      height = length,
+      angleDegAzi = 0.0,
+      angleDegTil = 0.0,
+      T_start = {TCeiling_start},
+      epsilon_1 = 0.9,
+      epsilon_2 = 0.9,
+      abs_1 = 0.0,
+      abs_2 = 0.4)
+      "Ceiling : Thermal wall model with 1D discretisation of the single layers"
+    annotation (Dialog(tab = "Opaque constructions", group = "model type"),
+      Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={30,60})));
+
+    BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes bottom(
+      constructionData = constructionBottom,
+      width = width,
+      height = length,
+      angleDegAzi = 0.0,
+      angleDegTil = 180.0,
+      T_start = {TBottom_start},
+      epsilon_2 = 0.0,
+      epsilon_1 = 0.95,
+      abs_1 = 0.0,
+      abs_2 = 0.0)
+      "Bottom : Thermal wall model with 1D discretisation of the single layers"
+    annotation (Dialog(tab = "Opaque constructions", group = "model type"),
+      Placement(transformation(extent={{-20,-20},{20,20}},rotation=270,origin={30,-60})));
+
+    BuildingSystems.Buildings.Constructions.Windows.Window window(
+      redeclare BuildingSystems.Buildings.Data.Constructions.Transparent.DoubleGlazing constructionData,
+      width = 0.2*width,
+      T_start=283.15,
+      height = 0.3*height,
+      angleDegAzi = -90.0)
+      "Window"
+    annotation (Dialog(tab = "Transparent constructions", group = "model type"),
+      Placement(transformation(extent={{-20,-20},{20,20}},rotation=0,origin={60,-30})));
+
+  equation
+
+    // connections between building components and the thermal zone
+    connect(wall_1.toSurfacePort_1, zone.toConstructionPorts[1])
+      annotation (Line(points={{-30,-56},{-30,-26},{0,-26},{0,-1.85714}}, color={0,0,0}));
+    connect(wall_2.toSurfacePort_1, zone.toConstructionPorts[2])
+      annotation (Line(points={{-30,56},{-30,-26},{0,-26},{0,-1.57143}}, color={0,0,0}));
+    connect(wall_3.toSurfacePort_1, zone.toConstructionPorts[3])
+      annotation (Line(points={{-56,-1.55431e-15},{-30,-1.55431e-15},{-30,-26}, {0,-26},{0,-1.28571}}, color={0,0,0}));
+    connect(wall_4.toSurfacePort_1, zone.toConstructionPorts[4])
+      annotation (Line(points={{56,30},{-30,30},{-30,-26},{0,-26},{0,-1}}, color={0,0,0}));
+    connect(bottom.toSurfacePort_1, zone.toConstructionPorts[5])
+      annotation (Line(points={{30,-56},{30,-28},{0,-28},{0,-0.714286}}, color={0,0,0}));
+    connect(ceiling.toSurfacePort_1, zone.toConstructionPorts[6])
+      annotation (Line(points={{30,56},{30,30},{-30,30},{-30,-26},{0,-26},{0,-0.428571}}, color={0,0,0}));
+    connect(window.toSurfacePort_1, zone.toConstructionPorts[7])
+      annotation (Line(points={{56,-30},{30,-30},{30,-28},{0,-28},{0,-0.142857}}, color={0,0,0}));
+
+    // connections between construction elements and environment
+    connect(wall_1.toSurfacePort_2, surfacesToAmbience.toConstructionPorts[1])
+      annotation (Line(points={{-30,-64},{-138,-64},{-138,2.66454e-15},{-170.8,2.66454e-15}}, color={0,0,0}));
+    connect(wall_2.toSurfacePort_2, surfacesToAmbience.toConstructionPorts[2])
+      annotation (Line(points={{-64,-5.55112e-16},{-117.4,-5.55112e-16},{-117.4,2.66454e-15},{-170.8,2.66454e-15}}, color={0,0,0}));
+    connect(wall_3.toSurfacePort_2, surfacesToAmbience.toConstructionPorts[3])
+      annotation (Line(points={{-30,64},{-30,86},{-136,86},{-136,2.66454e-15},{-170.8,2.66454e-15}}, color={0,0,0}));
+    connect(wall_4.toSurfacePort_2, surfacesToAmbience.toConstructionPorts[4])
+      annotation (Line(points={{64,30},{86,30},{86,88},{-30,88},{-30,86},{-136,86},{-136,2.66454e-15},{-170.8,2.66454e-15}}, color={0,0,0}));
+    connect(ceiling.toSurfacePort_2, surfacesToAmbience.toConstructionPorts[5])
+      annotation (Line(points={{30,64},{30,88},{-30,88},{-30,86},{-136,86},{-136,2.66454e-15},{-170.8,2.66454e-15}}, color={0,0,0}));
+    connect(window.toSurfacePort_2, surfacesToAmbience.toConstructionPorts[6])
+      annotation (Line(points={{64,-30},{86,-30},{86,88},{-30,88},{-30,86},{-136,86},{-136,2.66454e-15},{-170.8,2.66454e-15}}, color={0,0,0}));
+
+    // connections between construction elements and ground
+    connect(bottom.toSurfacePort_2, surfacesToSolids.toConstructionPorts[1])
+      annotation (Line(points={{30,-64},{1.33227e-15,-64},{1.33227e-15,-109.6}}, color={0,0,0}));
+
+    // air and moisture
+    connect(zone.TAir, TAir[1])
+      annotation (Line(points={{22,-2},{88,-2},{88,-70},{190,-70}}, color={0,0,127}));
+    connect(zone.xAir, xAir[1])
+      annotation (Line(points={{22,-14},{30,-14},{30,-4},{82,-4},{82,-90},{190,-90}}, color={0,0,127}));
+
+    // Prescribed airchange - depends on boolean prescribedAirchange
+    if prescribedAirchange then
+      // Ambient temperature of each thermal zones
+      connect(zone.TAirAmb, TAirAmb)
+        annotation (Line(points={{-22,-8},{-28,-8},{-28,2},{-26,2},{-26,26},{4,26},{4,82},{50,82},{50,120}}, color={0,0,127}));
+
+      // Airchange rates of each thermal zones
+      connect(zone.airchange, airchange[1])
+        annotation (Line(points={{-22,-4},{-22,22},{28,22},{28,4},{84,4},{84,40},{180,40}}, color={0,0,127}));
+
+      // Ambient moisture of each thermal zones
+      connect(zone.xAirAmb, xAirAmb)
+        annotation (Line(points={{-22,-16},{-28,-16},{-28,28},{-4,28},{-4,86},{28,86},{28,102},{70,102},{70,120}}, color={0,0,127}));
+    end if;
+
+    // Ideal heat load calculation - depends on boolean heatSources
+    if heatSources then
+      connect(zone.conHeatSourcesPorts, conHeatSourcesPorts);
+      connect(zone.radHeatSourcesPorts, radHeatSourcesPorts);
+    end if;
+
+    annotation (Line(points={{-56,-1.55431e-15},{-28,-1.55431e-15},{-28,-26},{0,-26},{0,1.75}}, color={0,0,0}));
+  end Building;
+
+  Modelica.Blocks.Interfaces.RealInput SC_wall1(min = 0.0, max = 1.0);
+    annotation (Dialog(group = "Solarmask related input"));
+  Modelica.Blocks.Interfaces.RealInput SC_wall2(min = 0.0, max = 1.0);
+    annotation (Dialog(group = "Solarmask related input"));
+  Modelica.Blocks.Interfaces.RealInput SC_wall3(min = 0.0, max = 1.0);
+    annotation (Dialog(group = "Solarmask related input"));
+  Modelica.Blocks.Interfaces.RealInput SC_wall4(min = 0.0, max = 1.0);
+    annotation (Dialog(group = "Solarmask related input"));
+  Modelica.Blocks.Interfaces.RealInput SC_ceiling(min = 0.0, max = 1.0);
+    annotation (Dialog(group = "Solarmask related input"));
+  Modelica.Blocks.Interfaces.RealInput SC_window(min = 0.0, max = 1.0);
+    annotation (Dialog(group = "Solarmask related input"));
+
+  BuildingSystems.Buildings.Ambience ambience(
+    nSurfaces = building.nSurfacesAmbience,
+    useSolarMask = true,
+    redeclare block WeatherData =
+      BuildingSystems.Climate.WeatherDataMeteonorm.Algeria_Tamanrasset_Meteonorm_ASCII)
+    annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+
+  Building building
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+
+equation
+
+  // connections between ambience and building
+  connect(ambience.toSurfacePorts, building.toAmbienceSurfacesPorts);
+  connect(ambience.TAirRef, building.TAirAmb);
+  connect(ambience.xAir, building.xAirAmb);
+  connect(ambience.toAirPorts, building.toAmbienceAirPorts);
+
+  // connections between inputs and solarmasks
+  connect(ambience.solarmask[1].SC, SC_wall1);
+  connect(ambience.solarmask[2].SC, SC_wall2);
+  connect(ambience.solarmask[3].SC, SC_wall3);
+  connect(ambience.solarmask[4].SC, SC_wall4);
+  connect(ambience.solarmask[5].SC, SC_ceiling);
+  connect(ambience.solarmask[6].SC, SC_window);
+
+  annotation(experiment(StartTime=1.728e+07, StopTime=1.73664e+07),
+  Documentation(info="<html>
+  <p>
+  Example that simulates a building using a solar mask.
+  The solar mask is calculated outside buildingSystems.
+  The shading coefficients of the wall exterior surfaces are input at each time step.
+  </p>
+  </html>",
+  revisions="<html>
+  <ul>
+  <li>
+  October 3, 2023 by Philippe Pinçon:<br/>
+  First implementation.
+  </li>
+  </ul>
+  </html>"));
+end MaskedBuilding;

--- a/BuildingSystems/Buildings/Constructions/Shadowing/Examples/MaskedWall.mo
+++ b/BuildingSystems/Buildings/Constructions/Shadowing/Examples/MaskedWall.mo
@@ -1,0 +1,91 @@
+within BuildingSystems.Buildings.Constructions.Shadowing.Examples;
+model MaskedWall
+  "Masked wall model"
+  extends Modelica.Icons.Example;
+
+  record Construction
+    extends BuildingSystems.Buildings.Data.Constructions.OpaqueThermalConstruction(
+      nLayers=2,
+      thickness={0.1,0.1},
+      material={BuildingSystems.HAM.Data.MaterialProperties.Thermal.Concrete(),
+                BuildingSystems.HAM.Data.MaterialProperties.Thermal.Concrete()});
+  end Construction;
+
+  BuildingSystems.Buildings.Constructions.Walls.WallThermal1DNodes wall(
+    position={0.0,0.0,0.5},
+    angleDegAzi = -90.0,
+    angleDegTil = 90.0,
+    height=1.0,
+    width=1.0,
+    nNodes={2,2},
+    redeclare Construction constructionData)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+  BuildingSystems.Buildings.Surfaces.SurfaceToAir surface2
+    annotation (Placement(transformation(extent={{2,-10},{22,10}})));
+  BuildingSystems.Buildings.Surfaces.SurfaceToAir surface1
+    annotation (Placement(transformation(extent={{-2,-10},{-22,10}})));
+
+  BuildingSystems.Buildings.Ambience ambience(
+    nSurfaces = 2,
+    useSolarMask = true,
+    redeclare block WeatherData =
+      BuildingSystems.Climate.WeatherDataMeteonorm.Algeria_Tamanrasset_Meteonorm_ASCII)
+    annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
+
+  Modelica.Blocks.Interfaces.RealInput SC_surface1(min = 0.0, max = 1.0);
+    annotation (Dialog(group = "Solarmask related input"));
+  Modelica.Blocks.Interfaces.RealInput SC_surface2(min = 0.0, max = 1.0);
+    annotation (Dialog(group = "Solarmask related input"));
+
+equation
+  connect(surface1.toConstructionPort, wall.toSurfacePort_1) annotation (Line(
+      points={{-11,0},{-8,0}},
+      color={0,0,0},
+      pattern=LinePattern.Solid,
+      smooth=Smooth.None));
+  connect(wall.toSurfacePort_2, surface2.toConstructionPort) annotation (Line(
+      points={{8,0},{11,0}},
+      color={0,0,0},
+      pattern=LinePattern.Solid,
+      smooth=Smooth.None));
+  connect(ambience.toSurfacePorts[1], surface1.toSurfacesPort) annotation (Line(
+      points={{-32,3.5},{-22,3.5},{-22,4},{-13,4}},
+      color={0,0,0},
+      pattern=LinePattern.Solid,
+      smooth=Smooth.None));
+  connect(ambience.toAirPorts[1], surface1.toAirPort) annotation (Line(
+      points={{-32,-4.5},{-22,-4.5},{-22,0},{-13,0}},
+      color={0,0,0},
+      pattern=LinePattern.Solid,
+      smooth=Smooth.None));
+  connect(ambience.toSurfacePorts[2], surface2.toSurfacesPort) annotation (Line(
+      points={{-32,4.5},{-24,4.5},{-24,16},{24,16},{24,4},{13,4}},
+      color={0,0,0},
+      pattern=LinePattern.Solid,
+      smooth=Smooth.None));
+  connect(ambience.toAirPorts[2], surface2.toAirPort) annotation (Line(
+      points={{-32,-3.5},{-28,-3.5},{-28,-6},{-24,-6},{-24,-14},{24,-14},{24,0},
+          {13,0}},
+      color={0,0,0},
+      pattern=LinePattern.Solid,
+      smooth=Smooth.None));
+  connect(ambience.solarmask[1].SC, SC_surface1);
+  connect(ambience.solarmask[2].SC, SC_surface2);
+
+  annotation(experiment(StartTime=1.728e+07, StopTime=1.73664e+07),
+  Documentation(info="<html>
+  <p>
+  Example that simulates a wall using a solar mask.
+  The solar mask is calculated outside buildingSystems.
+  The shading coefficients of the two wall surfaces are input at each time step.
+  </p>
+  </html>",
+  revisions="<html>
+  <ul>
+  <li>
+  October 3, 2023 by Philippe Pinçon:<br/>
+  First implementation.
+  </li>
+  </ul>
+  </html>"));
+end MaskedWall;

--- a/BuildingSystems/Buildings/Constructions/Shadowing/Examples/package.order
+++ b/BuildingSystems/Buildings/Constructions/Shadowing/Examples/package.order
@@ -1,1 +1,3 @@
 Embrasure
+MaskedBuilding
+MaskedWall

--- a/BuildingSystems/Buildings/Zones/ZoneTemplateAirvolumeMixedCO2.mo
+++ b/BuildingSystems/Buildings/Zones/ZoneTemplateAirvolumeMixedCO2.mo
@@ -1,0 +1,418 @@
+within BuildingSystems.Buildings.Zones;
+model ZoneTemplateAirvolumeMixedCO2
+  "Template model for a thermal zone with fully mixed air volume + CO2 source"
+  extends BuildingSystems.Buildings.BaseClasses.ZoneTemplateGeneralCO2(
+    redeclare package Medium = BuildingSystems.Media.Air(extraPropertiesNames={"CO2"}),
+    nHeatSourcesTotal = if calcIdealLoads then nHeatSources + 2 else nHeatSources);
+  parameter Modelica.Units.SI.HeatFlowRate Q_flow_heatingMax = Modelica.Constants.inf
+    "Maximal power for ideal heating"
+    annotation(Dialog(tab="General",group="Ideal heating and cooling"));
+  parameter Modelica.Units.SI.HeatFlowRate Q_flow_coolingMax = -Modelica.Constants.inf
+    "Maximal power for ideal cooling"
+    annotation(Dialog(tab="General",group="Ideal heating and cooling"));
+  parameter Real radiationportionIdealHeating = 0.5
+    "Radiation portion of the ideal heating"
+    annotation(Dialog(tab="General",group="Ideal heating and cooling"));
+  parameter Real radiationportionIdealCooling = 0.5
+    "Radiation portion of the ideal cooling"
+    annotation(Dialog(tab="General",group="Ideal heating and cooling"));
+  parameter Modelica.Units.SI.Length heightAirpath[nAirpathsInternal]=fill(0.0,nAirpathsInternal)
+    "Vertical height of each air path in the zone"
+    annotation(Dialog(tab="General",group="Air change"));
+  parameter Boolean heatSources = false
+    "True: heat sources present; false: no heat sources present"
+    annotation(Dialog(tab="General",group="Heat and moisture sources"));
+  parameter Integer nHeatSources = 0
+    "Number of internal heat sources of the thermal zone"
+    annotation(Evaluate=true, Dialog(connectorSizing=true, tab="General",group="Heat and moisture sources"));
+  parameter Boolean moistureSources = false
+    "True: moisture source present; false: no moisture source present"
+    annotation(Dialog(tab="General",group="Heat and moisture sources"));
+  parameter Boolean calcIdealLoads = true
+    "True: calculation of the ideal heating and cooling loads; false: no calculation"
+    annotation(Dialog(tab="General",group="Ideal heating and cooling"));
+  input BuildingSystems.Interfaces.Temp_KInput T_setHeating if calcIdealLoads
+    "Set air temperature for heating of the zone"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={-100,4}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={-110,70})));
+  input BuildingSystems.Interfaces.Temp_KInput T_setCooling if calcIdealLoads
+    "Set air temperature for cooling of the zone"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={-100,-10}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={-110,50})));
+  parameter Boolean calcThermalComfort = false
+    "true: PMV and PPD calculated, false: no thermal comfort assessment"
+    annotation(HideResult = true, Dialog(tab="Advanced",group="Thermal comfort"));
+  parameter Real clo = 0.5
+    "Clothing"
+    annotation(HideResult = true, Dialog(tab="Advanced",group="Thermal comfort"));
+  parameter Real met = 1.2
+    "Metabolism rate"
+    annotation(HideResult = true, Dialog(tab="Advanced",group="Thermal comfort"));
+  Modelica.Blocks.Interfaces.RealInput wme = 0.0
+    "External work"
+    annotation(HideResult = true, Dialog(tab="Advanced",group="Thermal comfort"));
+  parameter Modelica.Units.SI.Velocity vAir = 0.1
+     "Mean relative air velocity in the area of user presence"
+     annotation(HideResult = true, Dialog(tab="Advanced",group="Thermal comfort"));
+  parameter Modelica.Units.SI.Temperature T_start = 293.15
+    "Start air temperature of the zone"
+    annotation (Dialog(tab="Initialization"));
+  parameter Modelica.Units.SI.MassFraction x_start = 0.005
+    "Start air moisture of the zone"
+    annotation (Dialog(tab="Initialization"));
+  output BuildingSystems.Interfaces.HeatFlowRateOutput Q_flow_heating if calcIdealLoads
+    annotation (Placement(transformation(extent={{-52,28},{-32,48}}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,90})));
+  output BuildingSystems.Interfaces.HeatFlowRateOutput Q_flow_cooling if calcIdealLoads
+    annotation (Placement(transformation(extent={{-52,2},{-32,22}}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,70})));
+  output BuildingSystems.Interfaces.Temp_KOutput TAir
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={34,36}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,-10})));
+  output BuildingSystems.Interfaces.Moisture_absOutput xAir
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={34,46}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,-70})));
+  output BuildingSystems.Interfaces.PressureOutput pAirMean
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={34,26}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,origin={110,-90})));
+  output BuildingSystems.Interfaces.Temp_KOutput TOperative=
+    (airvolume.T[1] + radiationDistribution.TSurfMean) / 2.0
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={-100,92}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,-50})));
+  BuildingSystems.Interfaces.HeatPorts conHeatSourcesPorts[nHeatSources] if heatSources
+    "Heat ports of the convective heat sources"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={-66,80}), iconTransformation(extent={{-29,-7},{29,7}},rotation=180,origin={-49,-107})));
+  BuildingSystems.Interfaces.HeatPorts radHeatSourcesPorts[nHeatSources] if heatSources
+    "Heat ports of the long-wave radiation heat sources"
+    annotation (Placement(transformation(extent={{-10,10},{10,-10}},rotation=180,origin={-44,-4}), iconTransformation(extent={{-29,-7},{29,7}},rotation=180,origin={49,-107})));
+  BuildingSystems.Interfaces.MoisturePorts moistureSourcesPorts[nMoistureSources] if moistureSources
+    "Moisture ports of the moisture sources"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={-24,80}),
+      iconTransformation(extent={{-29,-7},{29,7}}, rotation=180,origin={49,107})));
+  input BuildingSystems.Interfaces.Temp_KInput TAirAmb if prescribedAirchange
+    "Air temperature of the building ambience"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={106,0}),
+      iconTransformation(extent={{-10,-10},{10,10}},origin={-110,-40})));
+  input BuildingSystems.Interfaces.Moisture_absInput xAirAmb if prescribedAirchange
+    "Absolute moisture of the building ambience"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={106,-16}),
+      iconTransformation(extent={{-10,-10},{10,10}},origin={-110,-80})));
+  input BuildingSystems.Interfaces.AirchangeRateInput airchange if prescribedAirchange
+    "Air change rate of the thermal zone"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={106,18}),
+      iconTransformation(extent={{-10,-10},{10,10}},origin={-110,-20})));
+  Modelica.Blocks.Interfaces.RealOutput PMV if calcThermalComfort
+    "Predicted mean vote"
+    annotation (Placement(transformation(extent={{-7,-7},{7,7}},rotation=0,origin={89,-27}),
+      iconTransformation(extent={{100,20},{120,40}})));
+  Modelica.Blocks.Interfaces.RealOutput PPD if calcThermalComfort
+    "Predicted percentage dissatisfied"
+    annotation (Placement(transformation(extent={{-7,-7},{7,7}},rotation=0,origin={73,-37}),
+      iconTransformation(extent={{100,0},{120,20}})));
+  parameter BuildingSystems.Buildings.Types.DataSource TAirSou=
+   BuildingSystems.Buildings.Types.DataSource.Calculation
+    "Data source for air temperature"
+    annotation (Evaluate=true, Dialog(tab="Advanced", group="Data source"));
+  parameter Modelica.Units.SI.Temperature TAir_constant = 293.15
+    "Constant air temperature (used if TAirSou=Parameter)"
+    annotation (Dialog(tab="Advanced", group="Data source"));
+  BuildingSystems.Interfaces.Temp_KInput TAir_in if
+    TAirSou == BuildingSystems.Buildings.Types.DataSource.Input
+    "Prediscribed external air temperature (used if TAirSou=Input)"
+    annotation(Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={110,54}),
+      iconTransformation(extent={{10,-10},{-10,10}},rotation=180,origin={-110,-60})));
+  parameter BuildingSystems.Buildings.Types.DataSource xAirSou=
+   BuildingSystems.Buildings.Types.DataSource.Calculation
+    "Data source for air moisture"
+    annotation (Evaluate=true, Dialog(tab="Advanced", group="Data source"));
+  parameter Modelica.Units.SI.MassFraction xAir_constant = 0.005
+    "Constant air moisture (used if xAirSou=Parameter)"
+    annotation (Dialog(tab="Advanced", group="Data source"));
+  BuildingSystems.Interfaces.Moisture_absInput xAir_in if
+    xAirSou == BuildingSystems.Buildings.Types.DataSource.Input
+    "Prediscribed external air moisture (used if xAirSou=Input)"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={110,38}),
+      iconTransformation(extent={{10,-10},{-10,10}},rotation=180,origin={-110,-100})));
+  Modelica.Blocks.Interfaces.RealInput C_in "Input port for concentration"
+    annotation (Placement(transformation(extent={{120,62},{100,82}}),
+        iconTransformation(extent={{140,-80},{160,-60}})));
+protected
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow phfHeating if calcIdealLoads
+    annotation (Placement(transformation(extent={{-50,52},{-42,60}})));
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow phfCooling if calcIdealLoads
+    annotation (Placement(transformation(extent={{-50,24},{-42,32}})));
+  BuildingSystems.Buildings.Comfort.ThermalComfort_DIN_EN_ISO_7730 thermalComfort if calcThermalComfort
+    "Thermal comfort assessment accordinng to DIN EN ISO 7730"
+    annotation (Placement(transformation(extent={{42,-50},{62,-30}})));
+  Modelica.Blocks.Sources.RealExpression cloVal(
+    y=clo) if calcThermalComfort
+    annotation (Placement(transformation(extent={{86,-60},{70,-42}})));
+  Modelica.Blocks.Sources.RealExpression metVal(
+    y=met) if calcThermalComfort
+    annotation (Placement(transformation(extent={{86,-72},{70,-54}})));
+  Modelica.Blocks.Sources.RealExpression wmeVal(
+    y=wme) if calcThermalComfort
+    annotation (Placement(transformation(extent={{86,-84},{70,-66}})));
+  Modelica.Blocks.Sources.RealExpression vAirVal(
+    y=vAir) if calcThermalComfort
+    annotation (Placement(transformation(extent={{86,-96},{70,-78}})));
+  Modelica.Blocks.Math.Gain ac2mf(
+    k=rho_nominal*airvolume.V/3600.0) if prescribedAirchange
+    "Transformation from air change in 1/h into air mass flow rate in kg/s"
+    annotation (Placement(transformation(extent={{94,14},{86,22}})));
+  BuildingSystems.Fluid.Sources.MassFlowSource_T airpathIn(
+    use_m_flow_in=true,
+    use_T_in=true,
+    use_Xi_in=true,
+    nPorts=1,
+    redeclare package Medium = BuildingSystems.Media.Air(extraPropertiesNames={"CO2"})) if prescribedAirchange
+    "Calculates the mass flow rate which is entering the zone"
+    annotation (Placement(transformation(extent={{60,-12},{44,4}})));
+  BuildingSystems.Fluid.Sources.MassFlowSource_T airpathOut(
+    use_m_flow_in = true,
+    nPorts=1,
+    redeclare package Medium = BuildingSystems.Media.Air(extraPropertiesNames={"CO2"})) if prescribedAirchange
+    "Calculates the mass flow rate which is leaving the zone"
+    annotation (Placement(transformation(extent={{60,72},{44,88}})));
+  Modelica.Blocks.Math.Gain mult(
+    k = -1.0) if prescribedAirchange
+    "Changes the sign of mass flow"
+    annotation (Placement(transformation(extent={{80,24},{72,32}})));
+  BuildingSystems.Buildings.Airvolumes.AirvolumeMixedCO2 airvolume(
+    geometryType = geometryType,
+    nSurfaces=nSurfaces,
+    V = V,
+    T_start={T_start},
+    x_start={x_start},
+    TSou=TAirSou,
+    T_constant=TAir_constant,
+    xSou=xAirSou,
+    x_constant=xAir_constant,
+    nHeatSources=nHeatSourcesTotal,
+    nMoistureSources=nMoistureSources,
+    nAirpaths=nAirpathsInternal)
+    "Air volume model"
+    annotation (Placement(transformation(extent={{-24,64},{24,16}})));
+  BuildingSystems.Buildings.BaseClasses.RelationRadiationConvection relRadConHeating(
+    radiationportion=radiationportionIdealHeating) if calcIdealLoads
+    "Relation convective and radiatrive heat"
+    annotation (Placement(transformation(extent={{-44,46},{-24,66}})));
+  Modelica.Blocks.Continuous.LimPID heatingLoad(
+    controllerType=Modelica.Blocks.Types.SimpleController.PI,
+    Ni=0.25,
+    k=V*500,
+    yMin=0.0,
+    Ti=50.0,
+    yMax=Q_flow_heatingMax) if calcIdealLoads
+    annotation (Placement(transformation(extent={{-68,62},{-56,50}})));
+  BuildingSystems.Buildings.BaseClasses.RelationRadiationConvection relRadConCooling(
+    radiationportion=radiationportionIdealCooling) if calcIdealLoads
+    "Relation convective and radiatrive cold"
+    annotation (Placement(transformation(extent={{-44,18},{-24,38}})));
+  Modelica.Blocks.Continuous.LimPID coolingLoad(
+    controllerType=Modelica.Blocks.Types.SimpleController.PI,
+    Ni=0.25,
+    k=V*500,
+    Ti=50.0,
+    yMax=0.0,
+    yMin=Q_flow_coolingMax) if calcIdealLoads
+   annotation (Placement(transformation(extent={{-68,34},{-56,22}})));
+  BuildingSystems.Airflow.Multizone.MediumColumn airpath[nAirpaths](
+    redeclare package Medium = Medium(extraPropertiesNames={"CO2"}),
+    h = {- 0.5 * height + heightAirpath[i] for i in 1:nAirpaths},
+    each densitySelection=BuildingSystems.Airflow.Multizone.Types.densitySelection.fromBottom) if
+       not prescribedAirchange
+    "Air columns for air paths"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=90,origin={-60,-60})));
+equation
+  // Flexible zone geometry
+  if geometryType == BuildingSystems.Buildings.Types.GeometryType.Flexible then
+    connect(airvolume.V_in, V_in);
+  end if;
+
+  // Connection construction surfaces <-> enclosed air
+  for i in 1:nConstructions loop
+    connect(surfaces.toAirPorts[i],airvolume.toSurfacePorts[i]);
+  end for;
+
+  // Air exchange by air path calculation
+  if not prescribedAirchange then
+    for i in 1:nAirpaths loop
+      connect(airpath[i].port_b, airvolume.airpathPorts[i])
+        annotation (Line(points={{-50,-60},{-40,-60},{-40,-94},{24,-94},{24,70},
+              {0,70},{0,59.2}}, color={0,127,255}));
+      connect(airpathPorts[i], airpath[i].port_a)
+        annotation (Line(points={{-94,-60},{-70,-60}}, color={0,127,255}));
+    end for;
+  end if;
+
+  // Internal heat sources
+  for i in 1:nHeatSources loop
+    connect(airvolume.heatSourcesPorts[i],conHeatSourcesPorts[i])
+      annotation (Line(points={{-19.2,30.4},{-19.2,80},{-66,80}}, color={127,0,0}));
+    connect(radiationDistribution.heatSourcesPorts[i],radHeatSourcesPorts[i]);
+  end for;
+
+  // Internal moisture sources
+  for i in 1:nMoistureSources loop
+    connect(moistureSourcesPorts[i], airvolume.moistureSourcesPorts[i])
+      annotation (Line(points={{-24,80},{-24,49.6},{-19.2,49.6}}, color={0,0,255}));
+  end for;
+
+  // Ideal load calculation
+  if calcIdealLoads then
+    connect(airvolume.heatSourcesPorts[nHeatSources+1], relRadConHeating.heatPortCv)
+      annotation (Line(
+        points={{-19.2,30.4},{-26,30.4},{-26,58},{-30,58}},
+        color={127,0,0},
+        smooth=Smooth.None));
+    connect(airvolume.heatSourcesPorts[nHeatSources+2], relRadConCooling.heatPortCv)
+      annotation (Line(
+        points={{-19.2,30.4},{-30,30.4},{-30,30}},
+        color={127,0,0},
+        smooth=Smooth.None));
+    connect(airvolume.T[1], coolingLoad.u_m) annotation (Line(
+        points={{19.2,35.2},{26,35.2},{26,6},{-72,6},{-72,38},{-62,38},{-62,35.2}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(airvolume.T[1], heatingLoad.u_m) annotation (Line(
+        points={{19.2,35.2},{26,35.2},{26,66},{-62,66},{-62,63.2}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(relRadConHeating.heatPortLw, radiationDistribution.heatSourcesPorts[nHeatSources+1])
+      annotation (Line(
+        points={{-30,54},{-26,54},{-26,4},{0,4},{0,-41.28}},
+        color={191,0,0},
+        smooth=Smooth.None));
+    connect(relRadConCooling.heatPortLw, radiationDistribution.heatSourcesPorts[nHeatSources+2])
+      annotation (Line(
+        points={{-30,26},{-30,4},{0,4},{0,-41.28}},
+        color={191,0,0},
+        smooth=Smooth.None));
+    connect(T_setHeating, heatingLoad.u_s) annotation (Line(
+        points={{-100,4},{-72,4},{-72,56},{-69.2,56}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(T_setCooling, coolingLoad.u_s) annotation (Line(
+        points={{-100,-10},{-72,-10},{-72,28},{-69.2,28}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(phfHeating.port, relRadConHeating.heatPort) annotation (Line(
+      points={{-42,56},{-37,56}},
+      color={191,0,0},
+      smooth=Smooth.None));
+    connect(heatingLoad.y, phfHeating.Q_flow) annotation (Line(
+        points={{-55.4,56},{-50,56}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(phfCooling.port, relRadConCooling.heatPort) annotation (Line(
+        points={{-42,28},{-37,28}},
+        color={191,0,0},
+        smooth=Smooth.None));
+    connect(phfCooling.Q_flow, coolingLoad.y) annotation (Line(
+        points={{-50,28},{-55.4,28}},
+        color={0,0,127},
+        smooth=Smooth.None));
+
+    //Connect Outputs with ideal heating/cooling loads
+    connect(Q_flow_heating, heatingLoad.y)
+      annotation (Line(points={{-42,38},{-55.4,38},{-55.4,56}}, color={0,0,127}));
+    connect(Q_flow_cooling, coolingLoad.y)
+      annotation (Line(points={{-42,12},{-55.4,12},{-55.4,28}}, color={0,0,127}));
+  end if;
+
+  // Prescribed air change
+  if prescribedAirchange then
+    connect(ac2mf.u, airchange) annotation (Line(
+        points={{94.8,18},{106,18}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(airpathIn.m_flow_in, ac2mf.y) annotation (Line(
+      points={{61.6,2.4},{80,2.4},{80,18},{85.6,18}},
+      color={0,0,127},
+      smooth=Smooth.None));
+    connect(airpathIn.T_in, TAirAmb) annotation (Line(
+      points={{61.6,-0.8},{86,-0.8},{86,0},{106,0}},
+      color={0,0,127},
+      smooth=Smooth.None));
+    connect(airpathOut.m_flow_in, mult.y) annotation (Line(
+        points={{61.6,86.4},{69.075,86.4},{69.075,28},{71.6,28}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(mult.u, ac2mf.y) annotation (Line(
+        points={{80.8,28},{85.6,28},{85.6,18}},
+        color={0,0,127},
+        smooth=Smooth.None));
+  end if;
+
+  // Thermal comfort assessment
+  if calcThermalComfort then
+    connect(TAir, thermalComfort.TAir)
+      annotation (Line(points={{34,36},{32,36},{32,-34},{45,-34}}, color={0,0,127}));
+    connect(radiationDistribution.TSurfMean, thermalComfort.Tr)
+      annotation (Line(points={{19.2,-60},{24,-60},{24,-37},{45,-37}}, color={0,0,127}));
+    connect(xAir, thermalComfort.xAir)
+      annotation (Line(points={{34,46},{34,-40},{45,-40}}, color={0,0,127}));
+    connect(thermalComfort.PMV, PMV)
+      annotation (Line(points={{61,-34},{64,-34},{64,-27},{89,-27}}, color={0,0,127}));
+    connect(thermalComfort.PPD, PPD)
+      annotation (Line(points={{61,-37},{73,-37}}, color={0,0,127}));
+    connect(cloVal.y, thermalComfort.clo)
+      annotation (Line(points={{69.2,-51},{47,-51},{47,-47}}, color={0,0,127}));
+    connect(metVal.y, thermalComfort.met)
+      annotation (Line(points={{69.2,-63},{50,-63},{50,-47}}, color={0,0,127}));
+    connect(wmeVal.y, thermalComfort.wme)
+      annotation (Line(points={{69.2,-75},{53,-75},{53,-47}}, color={0,0,127}));
+    connect(vAirVal.y, thermalComfort.vAir)
+      annotation (Line(points={{69.2,-87},{42,-87},{42,-43},{45,-43}}, color={0,0,127}));
+  end if;
+
+  connect(airvolume.T[1], TAir)
+    annotation (Line(points={{19.2,35.2},{22.6,35.2},{22.6,36},{34,36}}, color={0,0,127}));
+  connect(airvolume.x[1], xAir)
+    annotation (Line(points={{19.2,44.8},{24.6,44.8},{24.6,46},{34,46}}, color={0,0,127}));
+  connect(airvolume.p[1], pAirMean) annotation (Line(points={{19.2,25.6},{22.6,25.6},
+          {22.6,26},{34,26}}, color={0,0,127}));
+  connect(airpathIn.Xi_in[1], xAirAmb) annotation (Line(points={{61.6,-7.2},{80,
+          -7.2},{80,-16},{106,-16}}, color={0,0,127}));
+  connect(airpathIn.ports[1], airvolume.airpathPorts[1]) annotation (Line(
+        points={{44,-4},{44,74},{0,74},{0,59.2}},         color={0,127,255}));
+  connect(airpathOut.ports[1], airvolume.airpathPorts[2]) annotation (Line(
+        points={{44,80},{0,80},{0,59.2}},         color={0,127,255}));
+  connect(airvolume.T_in, TAir_in) annotation (Line(points={{19.2,30.4},{60,30.4},
+          {60,54},{110,54}}, color={0,0,127}));
+  connect(airvolume.x_in, xAir_in) annotation (Line(points={{19.2,40},{22,40},{22,
+          22},{66,22},{66,38},{110,38}}, color={0,0,127}));
+
+  connect(airvolume.C_in, C_in) annotation (Line(points={{18.24,54.4},{81.12,
+          54.4},{81.12,72},{110,72}}, color={0,0,127}));
+  annotation(defaultComponentName="zone",
+Documentation(info="<html>
+<p>
+This is a template model for a thermal zone with fully mixed air volume.
+</p>
+</html>", revisions="<html>
+<ul>
+<li>
+October 29, 2020 by Christoph Nytsch-Geusen:<br/>
+Adapted ti IBPSA library.
+</li>
+<li>
+January 3, 2020 by Christoph Nytsch-Geusen:<br/>
+Thermal comfort assessment added.
+</li>
+<li>
+September 19, 2018 by Christoph Nytsch-Geusen:<br/>
+Air path models against IBPSA 1 library models exchanged.
+</li>
+<li>
+January 25, 2017 by Christoph Nytsch-Geusen:<br/>
+Adapted to discretized air volume model.
+</li>
+<li>
+May 23, 2015 by Christoph Nytsch-Geusen:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end ZoneTemplateAirvolumeMixedCO2;

--- a/BuildingSystems/Buildings/Zones/ZoneTemplateAirvolumeMixedComfort.mo
+++ b/BuildingSystems/Buildings/Zones/ZoneTemplateAirvolumeMixedComfort.mo
@@ -1,0 +1,403 @@
+within BuildingSystems.Buildings.Zones;
+model ZoneTemplateAirvolumeMixedComfort
+  "Template model for a thermal zone with fully mixed air volume"
+  extends BuildingSystems.Buildings.BaseClasses.ZoneTemplateGeneral(
+    redeclare final package Medium = BuildingSystems.Media.Air,
+    nHeatSourcesTotal = if calcIdealLoads then nHeatSources + 2 else nHeatSources);
+  parameter Modelica.Units.SI.HeatFlowRate Q_flow_heatingMax=Modelica.Constants.inf
+    "Maximal power for ideal heating"
+    annotation (Dialog(tab="General", group="Ideal heating and cooling"));
+  parameter Modelica.Units.SI.HeatFlowRate Q_flow_coolingMax=-Modelica.Constants.inf
+    "Maximal power for ideal cooling"
+    annotation (Dialog(tab="General", group="Ideal heating and cooling"));
+  parameter Real radiationportionIdealHeating = 0.5
+    "Radiation portion of the ideal heating"
+    annotation(Dialog(tab="General",group="Ideal heating and cooling"));
+  parameter Real radiationportionIdealCooling = 0.5
+    "Radiation portion of the ideal cooling"
+    annotation(Dialog(tab="General",group="Ideal heating and cooling"));
+  parameter Modelica.Units.SI.Length heightAirpath[nAirpathsInternal]=fill(0.0,
+      nAirpathsInternal) "Vertical height of each air path in the zone"
+    annotation (Dialog(tab="General", group="Air change"));
+  parameter Boolean heatSources = false
+    "True: heat sources present; false: no heat sources present"
+    annotation(Dialog(tab="General",group="Heat and moisture sources"));
+  parameter Integer nHeatSources = 0
+    "Number of internal heat sources of the thermal zone"
+    annotation(Evaluate=true, Dialog(connectorSizing=true, tab="General",group="Heat and moisture sources"));
+  parameter Boolean moistureSources = false
+    "True: moisture source present; false: no moisture source present"
+    annotation(Dialog(tab="General",group="Heat and moisture sources"));
+  parameter Boolean calcIdealLoads = true
+    "True: calculation of the ideal heating and cooling loads; false: no calculation"
+    annotation(Dialog(tab="General",group="Ideal heating and cooling"));
+  input BuildingSystems.Interfaces.Temp_KInput T_setHeating if calcIdealLoads
+    "Set air temperature for heating of the zone"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={-100,4}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={-110,70})));
+  input BuildingSystems.Interfaces.Temp_KInput T_setCooling if calcIdealLoads
+    "Set air temperature for cooling of the zone"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={-100,-10}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={-110,50})));
+  parameter Boolean calcThermalComfort = false
+    "true: PMV and PPD calculated, false: no thermal comfort assessment"
+    annotation(HideResult = true, Dialog(tab="Advanced",group="Thermal comfort"));
+  BuildingSystems.Buildings.Comfort.ThermalComfortConnector comfortConnector
+    "Dynamic thermal comfort connector"
+    annotation(HideResult = false, Dialog(tab="Advanced",group="Thermal comfort"));
+  parameter Modelica.Units.SI.Temperature T_start = 293.15
+    "Start air temperature of the zone"
+    annotation (Dialog(tab="Initialization"));
+  parameter Modelica.Units.SI.MassFraction x_start=0.005
+    "Start air moisture of the zone" annotation (Dialog(tab="Initialization"));
+  output BuildingSystems.Interfaces.HeatFlowRateOutput Q_flow_heating if calcIdealLoads
+    annotation (Placement(transformation(extent={{-52,28},{-32,48}}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,90})));
+  output BuildingSystems.Interfaces.HeatFlowRateOutput Q_flow_cooling if calcIdealLoads
+    annotation (Placement(transformation(extent={{-52,2},{-32,22}}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,70})));
+  output BuildingSystems.Interfaces.Temp_KOutput TAir
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={34,36}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,-10})));
+  output BuildingSystems.Interfaces.Moisture_absOutput xAir
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={34,46}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,-70})));
+  output BuildingSystems.Interfaces.PressureOutput pAirMean
+    annotation (Placement(transformation(extent={{10,-10},{-10,10}},rotation=180,origin={34,26}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,origin={110,-90})));
+  output BuildingSystems.Interfaces.Temp_KOutput TOperative=
+    (airvolume.T[1] + radiationDistribution.TSurfMean) / 2.0
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={-100,92}),
+      iconTransformation(extent={{-10,-10},{10,10}},rotation=0,  origin={110,-50})));
+  BuildingSystems.Interfaces.HeatPorts conHeatSourcesPorts[nHeatSources] if heatSources
+    "Heat ports of the convective heat sources"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={-66,80}), iconTransformation(extent={{-29,-7},{29,7}},rotation=180,origin={-49,-107})));
+  BuildingSystems.Interfaces.HeatPorts radHeatSourcesPorts[nHeatSources] if heatSources
+    "Heat ports of the long-wave radiation heat sources"
+    annotation (Placement(transformation(extent={{-10,10},{10,-10}},rotation=180,origin={-44,-4}), iconTransformation(extent={{-29,-7},{29,7}},rotation=180,origin={49,-107})));
+  BuildingSystems.Interfaces.MoisturePorts moistureSourcesPorts[nMoistureSources] if moistureSources
+    "Moisture ports of the moisture sources"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={-24,80}),
+      iconTransformation(extent={{-29,-7},{29,7}}, rotation=180,origin={49,107})));
+  input BuildingSystems.Interfaces.Temp_KInput TAirAmb if prescribedAirchange
+    "Air temperature of the building ambience"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={106,0}),
+      iconTransformation(extent={{-10,-10},{10,10}},origin={-110,-40})));
+  input BuildingSystems.Interfaces.Moisture_absInput xAirAmb if prescribedAirchange
+    "Absolute moisture of the building ambience"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={106,-16}),
+      iconTransformation(extent={{-10,-10},{10,10}},origin={-110,-80})));
+  input BuildingSystems.Interfaces.AirchangeRateInput airchange if prescribedAirchange
+    "Air change rate of the thermal zone"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},origin={106,18}),
+      iconTransformation(extent={{-10,-10},{10,10}},origin={-110,-20})));
+  Modelica.Blocks.Interfaces.RealOutput PMV if calcThermalComfort
+    "Predicted mean vote"
+    annotation (Placement(transformation(extent={{-7,-7},{7,7}},rotation=0,origin={89,-27}),
+      iconTransformation(extent={{100,20},{120,40}})));
+  Modelica.Blocks.Interfaces.RealOutput PPD if calcThermalComfort
+    "Predicted percentage dissatisfied"
+    annotation (Placement(transformation(extent={{-7,-7},{7,7}},rotation=0,origin={73,-37}),
+      iconTransformation(extent={{100,0},{120,20}})));
+  parameter BuildingSystems.Buildings.Types.DataSource TAirSou=
+   BuildingSystems.Buildings.Types.DataSource.Calculation
+    "Data source for air temperature"
+    annotation (Evaluate=true, Dialog(tab="Advanced", group="Data source"));
+  parameter Modelica.Units.SI.Temperature TAir_constant=293.15
+    "Constant air temperature (used if TAirSou=Parameter)"
+    annotation (Dialog(tab="Advanced", group="Data source"));
+  BuildingSystems.Interfaces.Temp_KInput TAir_in
+ if TAirSou == BuildingSystems.Buildings.Types.DataSource.Input
+    "Prediscribed external air temperature (used if TAirSou=Input)"
+    annotation(Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={110,54}),
+      iconTransformation(extent={{10,-10},{-10,10}},rotation=180,origin={-110,-60})));
+  parameter BuildingSystems.Buildings.Types.DataSource xAirSou=
+   BuildingSystems.Buildings.Types.DataSource.Calculation
+    "Data source for air moisture"
+    annotation (Evaluate=true, Dialog(tab="Advanced", group="Data source"));
+  parameter Modelica.Units.SI.MassFraction xAir_constant=0.005
+    "Constant air moisture (used if xAirSou=Parameter)"
+    annotation (Dialog(tab="Advanced", group="Data source"));
+  BuildingSystems.Interfaces.Moisture_absInput xAir_in
+ if xAirSou == BuildingSystems.Buildings.Types.DataSource.Input
+    "Prediscribed external air moisture (used if xAirSou=Input)"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=180,origin={110,38}),
+      iconTransformation(extent={{10,-10},{-10,10}},rotation=180,origin={-110,-100})));
+protected
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow phfHeating if calcIdealLoads
+    annotation (Placement(transformation(extent={{-50,52},{-42,60}})));
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedHeatFlow phfCooling if calcIdealLoads
+    annotation (Placement(transformation(extent={{-50,24},{-42,32}})));
+  BuildingSystems.Buildings.Comfort.ThermalComfort_DIN_EN_ISO_7730 thermalComfort if calcThermalComfort
+    "Thermal comfort assessment accordinng to DIN EN ISO 7730"
+    annotation (Placement(transformation(extent={{42,-50},{62,-30}})));
+  Modelica.Blocks.Sources.RealExpression cloVal(
+    y=comfortConnector.clo_out) if calcThermalComfort
+    annotation (Placement(transformation(extent={{86,-60},{70,-42}})));
+  Modelica.Blocks.Sources.RealExpression metVal(
+    y=comfortConnector.met_out) if calcThermalComfort
+    annotation (Placement(transformation(extent={{86,-72},{70,-54}})));
+  Modelica.Blocks.Sources.RealExpression wmeVal(
+    y=comfortConnector.wme_out) if calcThermalComfort
+    annotation (Placement(transformation(extent={{86,-84},{70,-66}})));
+  Modelica.Blocks.Sources.RealExpression vAirVal(
+    y=comfortConnector.vAir_out) if calcThermalComfort
+    annotation (Placement(transformation(extent={{86,-96},{70,-78}})));
+  Modelica.Blocks.Math.Gain ac2mf(
+    k=rho_nominal*airvolume.V/3600.0) if prescribedAirchange
+    "Transformation from air change in 1/h into air mass flow rate in kg/s"
+    annotation (Placement(transformation(extent={{94,14},{86,22}})));
+  BuildingSystems.Fluid.Sources.MassFlowSource_T airpathIn(
+    use_m_flow_in=true,
+    use_T_in=true,
+    use_Xi_in=true,
+    nPorts=1,
+    redeclare package Medium = BuildingSystems.Media.Air) if prescribedAirchange
+    "Calculates the mass flow rate which is entering the zone"
+    annotation (Placement(transformation(extent={{60,-12},{44,4}})));
+  BuildingSystems.Fluid.Sources.MassFlowSource_T airpathOut(
+    use_m_flow_in = true,
+    nPorts=1,
+    redeclare package Medium = BuildingSystems.Media.Air) if prescribedAirchange
+    "Calculates the mass flow rate which is leaving the zone"
+    annotation (Placement(transformation(extent={{60,72},{44,88}})));
+  Modelica.Blocks.Math.Gain mult(
+    k = -1.0) if prescribedAirchange
+    "Changes the sign of mass flow"
+    annotation (Placement(transformation(extent={{80,24},{72,32}})));
+  BuildingSystems.Buildings.Airvolumes.AirvolumeMixed airvolume(
+    geometryType = geometryType,
+    nSurfaces=nSurfaces,
+    V = V,
+    T_start={T_start},
+    x_start={x_start},
+    TSou=TAirSou,
+    T_constant=TAir_constant,
+    xSou=xAirSou,
+    x_constant=xAir_constant,
+    nHeatSources=nHeatSourcesTotal,
+    nMoistureSources=nMoistureSources,
+    nAirpaths=nAirpathsInternal)
+    "Air volume model"
+    annotation (Placement(transformation(extent={{-24,64},{24,16}})));
+  BuildingSystems.Buildings.BaseClasses.RelationRadiationConvection relRadConHeating(
+    radiationportion=radiationportionIdealHeating) if calcIdealLoads
+    "Relation convective and radiatrive heat"
+    annotation (Placement(transformation(extent={{-44,46},{-24,66}})));
+  Modelica.Blocks.Continuous.LimPID heatingLoad(
+    controllerType=Modelica.Blocks.Types.SimpleController.PI,
+    Ni=0.25,
+    k=V*500,
+    yMin=0.0,
+    Ti=50.0,
+    yMax=Q_flow_heatingMax) if calcIdealLoads
+    annotation (Placement(transformation(extent={{-68,62},{-56,50}})));
+  BuildingSystems.Buildings.BaseClasses.RelationRadiationConvection relRadConCooling(
+    radiationportion=radiationportionIdealCooling) if calcIdealLoads
+    "Relation convective and radiatrive cold"
+    annotation (Placement(transformation(extent={{-44,18},{-24,38}})));
+  Modelica.Blocks.Continuous.LimPID coolingLoad(
+    controllerType=Modelica.Blocks.Types.SimpleController.PI,
+    Ni=0.25,
+    k=V*500,
+    Ti=50.0,
+    yMax=0.0,
+    yMin=Q_flow_coolingMax) if calcIdealLoads
+   annotation (Placement(transformation(extent={{-68,34},{-56,22}})));
+  BuildingSystems.Airflow.Multizone.MediumColumn airpath[nAirpaths](
+    redeclare package Medium = Medium,
+    h = {- 0.5 * height + heightAirpath[i] for i in 1:nAirpaths},
+    each densitySelection=BuildingSystems.Airflow.Multizone.Types.densitySelection.fromBottom)
+    if not prescribedAirchange
+    "Air columns for air paths"
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},rotation=90,origin={-60,-60})));
+equation
+  // Flexible zone geometry
+  if geometryType == BuildingSystems.Buildings.Types.GeometryType.Flexible then
+    connect(airvolume.V_in, V_in);
+  end if;
+
+  // Connection construction surfaces <-> enclosed air
+  for i in 1:nConstructions loop
+    connect(surfaces.toAirPorts[i],airvolume.toSurfacePorts[i]);
+  end for;
+
+  // Air exchange by air path calculation
+  if not prescribedAirchange then
+    for i in 1:nAirpaths loop
+      connect(airpath[i].port_b, airvolume.airpathPorts[i])
+        annotation (Line(points={{-50,-60},{-40,-60},{-40,-94},{24,-94},{24,70},
+              {0,70},{0,59.2}}, color={0,127,255}));
+      connect(airpathPorts[i], airpath[i].port_a)
+        annotation (Line(points={{-94,-60},{-70,-60}}, color={0,127,255}));
+    end for;
+  end if;
+
+  // Internal heat sources
+  for i in 1:nHeatSources loop
+    connect(airvolume.heatSourcesPorts[i],conHeatSourcesPorts[i])
+      annotation (Line(points={{-19.2,30.4},{-19.2,80},{-66,80}}, color={127,0,0}));
+    connect(radiationDistribution.heatSourcesPorts[i],radHeatSourcesPorts[i]);
+  end for;
+
+  // Internal moisture sources
+  for i in 1:nMoistureSources loop
+    connect(moistureSourcesPorts[i], airvolume.moistureSourcesPorts[i])
+      annotation (Line(points={{-24,80},{-24,49.6},{-19.2,49.6}}, color={0,0,255}));
+  end for;
+
+  // Ideal load calculation
+  if calcIdealLoads then
+    connect(airvolume.heatSourcesPorts[nHeatSources+1], relRadConHeating.heatPortCv)
+      annotation (Line(
+        points={{-19.2,30.4},{-26,30.4},{-26,58},{-30,58}},
+        color={127,0,0},
+        smooth=Smooth.None));
+    connect(airvolume.heatSourcesPorts[nHeatSources+2], relRadConCooling.heatPortCv)
+      annotation (Line(
+        points={{-19.2,30.4},{-30,30.4},{-30,30}},
+        color={127,0,0},
+        smooth=Smooth.None));
+    connect(airvolume.T[1], coolingLoad.u_m) annotation (Line(
+        points={{19.2,35.2},{26,35.2},{26,6},{-72,6},{-72,38},{-62,38},{-62,35.2}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(airvolume.T[1], heatingLoad.u_m) annotation (Line(
+        points={{19.2,35.2},{26,35.2},{26,66},{-62,66},{-62,63.2}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(relRadConHeating.heatPortLw, radiationDistribution.heatSourcesPorts[nHeatSources+1])
+      annotation (Line(
+        points={{-30,54},{-26,54},{-26,4},{0,4},{0,-41.28}},
+        color={191,0,0},
+        smooth=Smooth.None));
+    connect(relRadConCooling.heatPortLw, radiationDistribution.heatSourcesPorts[nHeatSources+2])
+      annotation (Line(
+        points={{-30,26},{-30,4},{0,4},{0,-41.28}},
+        color={191,0,0},
+        smooth=Smooth.None));
+    connect(T_setHeating, heatingLoad.u_s) annotation (Line(
+        points={{-100,4},{-72,4},{-72,56},{-69.2,56}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(T_setCooling, coolingLoad.u_s) annotation (Line(
+        points={{-100,-10},{-72,-10},{-72,28},{-69.2,28}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(phfHeating.port, relRadConHeating.heatPort) annotation (Line(
+      points={{-42,56},{-37,56}},
+      color={191,0,0},
+      smooth=Smooth.None));
+    connect(heatingLoad.y, phfHeating.Q_flow) annotation (Line(
+        points={{-55.4,56},{-50,56}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(phfCooling.port, relRadConCooling.heatPort) annotation (Line(
+        points={{-42,28},{-37,28}},
+        color={191,0,0},
+        smooth=Smooth.None));
+    connect(phfCooling.Q_flow, coolingLoad.y) annotation (Line(
+        points={{-50,28},{-55.4,28}},
+        color={0,0,127},
+        smooth=Smooth.None));
+
+    //Connect Outputs with ideal heating/cooling loads
+    connect(Q_flow_heating, heatingLoad.y)
+      annotation (Line(points={{-42,38},{-55.4,38},{-55.4,56}}, color={0,0,127}));
+    connect(Q_flow_cooling, coolingLoad.y)
+      annotation (Line(points={{-42,12},{-55.4,12},{-55.4,28}}, color={0,0,127}));
+  end if;
+
+  // Prescribed air change
+  if prescribedAirchange then
+    connect(ac2mf.u, airchange) annotation (Line(
+        points={{94.8,18},{106,18}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(airpathIn.m_flow_in, ac2mf.y) annotation (Line(
+      points={{61.6,2.4},{80,2.4},{80,18},{85.6,18}},
+      color={0,0,127},
+      smooth=Smooth.None));
+    connect(airpathIn.T_in, TAirAmb) annotation (Line(
+      points={{61.6,-0.8},{86,-0.8},{86,0},{106,0}},
+      color={0,0,127},
+      smooth=Smooth.None));
+    connect(airpathOut.m_flow_in, mult.y) annotation (Line(
+        points={{61.6,86.4},{69.075,86.4},{69.075,28},{71.6,28}},
+        color={0,0,127},
+        smooth=Smooth.None));
+    connect(mult.u, ac2mf.y) annotation (Line(
+        points={{80.8,28},{85.6,28},{85.6,18}},
+        color={0,0,127},
+        smooth=Smooth.None));
+  end if;
+
+  // Thermal comfort assessment
+  if calcThermalComfort then
+    connect(TAir, thermalComfort.TAir)
+      annotation (Line(points={{34,36},{32,36},{32,-34},{45,-34}}, color={0,0,127}));
+    connect(radiationDistribution.TSurfMean, thermalComfort.Tr)
+      annotation (Line(points={{19.2,-60},{24,-60},{24,-37},{45,-37}}, color={0,0,127}));
+    connect(xAir, thermalComfort.xAir)
+      annotation (Line(points={{34,46},{34,-40},{45,-40}}, color={0,0,127}));
+    connect(thermalComfort.PMV, PMV)
+      annotation (Line(points={{61,-34},{64,-34},{64,-27},{89,-27}}, color={0,0,127}));
+    connect(thermalComfort.PPD, PPD)
+      annotation (Line(points={{61,-37},{73,-37}}, color={0,0,127}));
+    connect(cloVal.y, thermalComfort.clo)
+      annotation (Line(points={{69.2,-51},{47,-51},{47,-47}}, color={0,0,127}));
+    connect(metVal.y, thermalComfort.met)
+      annotation (Line(points={{69.2,-63},{50,-63},{50,-47}}, color={0,0,127}));
+    connect(wmeVal.y, thermalComfort.wme)
+      annotation (Line(points={{69.2,-75},{53,-75},{53,-47}}, color={0,0,127}));
+    connect(vAirVal.y, thermalComfort.vAir)
+      annotation (Line(points={{69.2,-87},{42,-87},{42,-43},{45,-43}}, color={0,0,127}));
+  end if;
+
+  connect(airvolume.T[1], TAir)
+    annotation (Line(points={{19.2,35.2},{22.6,35.2},{22.6,36},{34,36}}, color={0,0,127}));
+  connect(airvolume.x[1], xAir)
+    annotation (Line(points={{19.2,44.8},{24.6,44.8},{24.6,46},{34,46}}, color={0,0,127}));
+  connect(airvolume.p[1], pAirMean) annotation (Line(points={{19.2,25.6},{22.6,25.6},
+          {22.6,26},{34,26}}, color={0,0,127}));
+  connect(airpathIn.Xi_in[1], xAirAmb) annotation (Line(points={{61.6,-7.2},{80,
+          -7.2},{80,-16},{106,-16}}, color={0,0,127}));
+  connect(airpathIn.ports[1], airvolume.airpathPorts[1]) annotation (Line(
+        points={{44,-4},{44,74},{0,74},{0,59.2}},         color={0,127,255}));
+  connect(airpathOut.ports[1], airvolume.airpathPorts[2]) annotation (Line(
+        points={{44,80},{0,80},{0,59.2}},         color={0,127,255}));
+  connect(airvolume.T_in, TAir_in) annotation (Line(points={{19.2,30.4},{60,30.4},
+          {60,54},{110,54}}, color={0,0,127}));
+  connect(airvolume.x_in, xAir_in) annotation (Line(points={{19.2,40},{22,40},{22,
+          22},{66,22},{66,38},{110,38}}, color={0,0,127}));
+
+  annotation(defaultComponentName="zone",
+Documentation(info="<html>
+<p>
+This is a template model for a thermal zone with fully mixed air volume.
+</p>
+</html>", revisions="<html>
+<ul>
+<li>
+October 29, 2020 by Christoph Nytsch-Geusen:<br/>
+Adapted ti IBPSA library.
+</li>
+<li>
+January 3, 2020 by Christoph Nytsch-Geusen:<br/>
+Thermal comfort assessment added.
+</li>
+<li>
+September 19, 2018 by Christoph Nytsch-Geusen:<br/>
+Air path models against IBPSA 1 library models exchanged.
+</li>
+<li>
+January 25, 2017 by Christoph Nytsch-Geusen:<br/>
+Adapted to discretized air volume model.
+</li>
+<li>
+May 23, 2015 by Christoph Nytsch-Geusen:<br/>
+First implementation.
+</li>
+</ul>
+</html>"));
+end ZoneTemplateAirvolumeMixedComfort;

--- a/BuildingSystems/Buildings/Zones/package.order
+++ b/BuildingSystems/Buildings/Zones/package.order
@@ -1,3 +1,4 @@
 ZoneTemplateAirvolume3D
 ZoneTemplateAirvolumeMixed
+ZoneTemplateAirvolumeMixedCO2
 Examples

--- a/BuildingSystems/Buildings/Zones/package.order
+++ b/BuildingSystems/Buildings/Zones/package.order
@@ -1,4 +1,5 @@
 ZoneTemplateAirvolume3D
 ZoneTemplateAirvolumeMixed
 ZoneTemplateAirvolumeMixedCO2
+ZoneTemplateAirvolumeMixedComfort
 Examples


### PR DESCRIPTION
# Issue Description

### Problem

We want to be able to dynamically change the following parameters: 
- The clothing : `clo`
- The metabolism rate : `met`
- The external work : `wme`
- The mean relative air velocity in the area of the user presence  : `vAir`

In the current situation, these parameters contained in the `ZoneTemplateAirVolumeMixed` template can only be modified at initialization. We therefore need to be able to connect these variables to inputs at the outermost level of a fmu file. If inputs are contained in a submodel of the fmu, then they are not dynamically modifiable, unless they are connected to inputs at a higher level of the fmu.

### Solution

We're going to create a new zone model, based on a new object that will act as a connector, so that we always have the same number of unknowns and equations.

We'll create a model called `ThermalComfortConnector`. 
We'll create input and output parameters. Input parameters will be connected to modifiable inputs outside the thermal zone model, and output parameters will be connected to the `ThermalComfort_DIN_EN_ISO_7730` object. 

We leave it to the reviewer to look at the code for a better understanding.

Created files : 
- `BuildingSystems/Buildings/Zones/ZoneTemplateAirvolumeMixedComfort.mo`
- `BuildingSystems/Buildings/Zones/package.order`
- `BuildingSystems/Buildings/Comfort/ThermalComfortConnector.mo`
- `BuildingSystems/Buildings/Comfort/package.order`

